### PR TITLE
Fix German (de) localization of Focus for iOS

### DIFF
--- a/de/focus-ios.xliff
+++ b/de/focus-ios.xliff
@@ -710,7 +710,7 @@
       </trans-unit>
       <trans-unit id="trackingProtection.disabledLabel">
         <source>Tracking Protection off</source>
-        <target>Schutz vor Aktivitätenverfolgung aus</target>
+        <target>Tracking-Schutz aus</target>
         <note>text showing the tracking protection is disabled.</note>
       </trans-unit>
       <trans-unit id="trackingProtection.learnMore">
@@ -730,7 +730,7 @@
       </trans-unit>
       <trans-unit id="trackingProtection.toggleLabel">
         <source>Tracking Protection</source>
-        <target>Schutz vor Aktivitätenverfolgung</target>
+        <target>Tracking-Schutz</target>
         <note>Text for the toggle that temporarily disables tracking protection.</note>
       </trans-unit>
       <trans-unit id="trackingProtection.trackerDescriptionLabel">


### PR DESCRIPTION
Use a shorter label for the tracking protection toggle to prevent
the toggle from disappearing from the tracking protection sidebar.

This replaces https://github.com/mozilla-mobile/focus-ios/pull/848 and should solve https://github.com/mozilla-mobile/focus-ios/pull/847.

@boek