### PR TITLE
String Export 2021-08-19

### DIFF
--- a/af/focus-ios.xliff
+++ b/af/focus-ios.xliff
@@ -671,6 +671,10 @@
         <source>SIRI SHORTCUTS</source>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
@@ -682,6 +686,10 @@
       <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -706,6 +714,10 @@
       <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -858,6 +870,14 @@
       <trans-unit id="trackingProtection.analyticTrackerLabel">
         <source>Analytic trackers</source>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/an/focus-ios.xliff
+++ b/an/focus-ios.xliff
@@ -723,6 +723,10 @@
         <source>SIRI SHORTCUTS</source>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
@@ -735,6 +739,10 @@
       <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -759,6 +767,10 @@
       <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -927,6 +939,14 @@
         <source>Analytic trackers</source>
         <target>Trazadors analiticos</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/ar/focus-ios.xliff
+++ b/ar/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>اختصارات سيري</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>ابحث في الصفحة</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>إجراءات الصفحة</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>شارِك الصفحة مع…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>متعقبات التحليل</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/ast/focus-ios.xliff
+++ b/ast/focus-ios.xliff
@@ -722,6 +722,10 @@
         <source>SIRI SHORTCUTS</source>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
@@ -734,6 +738,10 @@
       <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -758,6 +766,10 @@
       <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -926,6 +938,14 @@
         <source>Analytic trackers</source>
         <target>Rastrexadores d'analítiques</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/az/focus-ios.xliff
+++ b/az/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>SIRI QISAYOLLARI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Səhifədə Tap</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>Səhifə Əməliyyatları</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>Səhifəni Paylaş...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>Analiz izləyiciləri</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/bg/focus-ios.xliff
+++ b/bg/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>ДЕЙСТВИЯ ЧРЕЗ SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Търсене в страницата</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>Действия със страницата</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>Споделяне на страницата с…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>Проследяващи аналитични елементи</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/bn/focus-ios.xliff
+++ b/bn/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>SIRI শর্টকার্ট</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>পাতায় অনুসন্ধান</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>পেজ একশন</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>পাতা শেয়ার করুন...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>এনালিটিক ট্র্যাকার</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/br/focus-ios.xliff
+++ b/br/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>BERRADENNOÙ SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Kavout er bajennad</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>Obererezhioù ar bajenn</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>Rannañ ar bajenn gant...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>Heulieroù digejañ</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/bs/focus-ios.xliff
+++ b/bs/focus-ios.xliff
@@ -739,6 +739,10 @@
         <source>SIRI SHORTCUTS</source>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Pronađi na stranici</target>
@@ -752,6 +756,10 @@
       <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -777,6 +785,10 @@
       <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -948,6 +960,14 @@
         <source>Analytic trackers</source>
         <target>Analitički tragači</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/ca/focus-ios.xliff
+++ b/ca/focus-ios.xliff
@@ -150,7 +150,6 @@
       </trans-unit>
       <trans-unit id="About.safariBullet2">
         <source>Block web fonts to reduce page size</source>
-        <target>Blocar els tipus de lletra web per reduir la mida de la pàgina</target>
         <note>Label on About screen</note>
       </trans-unit>
       <trans-unit id="About.safariBulletHeader">
@@ -597,7 +596,6 @@
       </trans-unit>
       <trans-unit id="Settings.blockOtherMessage">
         <source>Blocking other content trackers may break some videos and web pages.</source>
-        <target>Si bloqueu altres elements de seguiment de contingut, és possible que alguns vídeos i pàgines web no funcionin correctament.</target>
         <note>Alert message shown when toggling the Content blocker</note>
       </trans-unit>
       <trans-unit id="Settings.blockOtherNo2">
@@ -688,7 +686,6 @@
       </trans-unit>
       <trans-unit id="Settings.toggleBlockFonts">
         <source>Block web fonts</source>
-        <target>Bloca tipus de lletra web</target>
         <note>Label for toggle on main screen</note>
       </trans-unit>
       <trans-unit id="Settings.toggleBlockOther2">
@@ -757,6 +754,10 @@
         <target>DRECERES DE SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Cerca a la pàgina</target>
@@ -771,6 +772,10 @@
         <source>Page Actions</source>
         <target>Accions de la pàgina</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +806,10 @@
         <source>Share Page With...</source>
         <target>Comparteix la pàgina amb...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +994,14 @@
         <source>Analytic trackers</source>
         <target>Elements de seguiment d'anàlisi</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/cs/focus-ios.xliff
+++ b/cs/focus-ios.xliff
@@ -1,36 +1,35 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Blockzilla/en.lproj/InfoPlist.strings" source-language="en" target-language="cs" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="NSCameraUsageDescription" xml:space="preserve">
+      <trans-unit id="NSCameraUsageDescription">
         <source>This lets you take and upload photos.</source>
         <target>Toto vám dovolí pořizovat a nahrávat fotografie.</target>
         <note>Privacy - Camera Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSFaceIDUsageDescription" xml:space="preserve">
+      <trans-unit id="NSFaceIDUsageDescription">
         <source>This lets you unlock the app.</source>
         <target>Toto vám umožní odemknout aplikaci.</target>
         <note>Privacy - Face ID Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSLocationWhenInUseUsageDescription" xml:space="preserve">
+      <trans-unit id="NSLocationWhenInUseUsageDescription">
         <source>Websites you visit may request your location.</source>
         <target>Servery, které navštěvujete, mohou chtít znát vaše umístění.</target>
         <note>Privacy - Location When In Use Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSMicrophoneUsageDescription" xml:space="preserve">
+      <trans-unit id="NSMicrophoneUsageDescription">
         <source>This lets you take and upload videos.</source>
         <target>Toto vám dovolí pořizovat a nahrávat videa.</target>
         <note>Privacy - Microphone Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSPhotoLibraryAddUsageDescription" xml:space="preserve">
+      <trans-unit id="NSPhotoLibraryAddUsageDescription">
         <source>This lets you save and upload photos.</source>
         <target>Toto vám dovolí ukládat a nahrávat fotografie.</target>
         <note>Privacy - Photo Library Additions Usage Description</note>
       </trans-unit>
-      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen" xml:space="preserve">
+      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen">
         <source>Erase and Open</source>
         <target>Vymazat a otevřít</target>
         <note>This is the menu item that appears when you long press the Focus icon on the phone home screen.</note>
@@ -42,7 +41,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intents.Erase.Title" xml:space="preserve">
+      <trans-unit id="Intents.Erase.Title">
         <source>Erase</source>
         <target>Vymazat</target>
         <note>Title of the Erase intent.</note>
@@ -54,42 +53,42 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intro.Slides.History.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Description">
         <source>Clear your entire browsing session history, passwords, cookies anytime with a single tap.</source>
         <target>Vyčistěte kdykoli celou vaši historii prohlížení, hesla a soubory cookie jedním klepnutím.</target>
         <note>Description for the 'History' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.History.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Title">
         <source>Your history is history</source>
         <target>Historie vašeho prohlížení je minulostí</target>
         <note>Title for the third  panel 'History' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Next.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Next.Button">
         <source>Next</source>
         <target>Další</target>
         <note>Button to go to the next card in Focus onboarding.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Description">
         <source>Searching for something different? Choose a different search engine.</source>
         <target>Hledáte něco jiného? Zvolte si jako výchozí jiný vyhledávač.</target>
         <note>Description for the 'Favorite Search Engine' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Title">
         <source>Your search, your way</source>
         <target>Vyhledávání jak vy chcete</target>
         <note>Title for the second  panel 'Search' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Skip.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Skip.Button">
         <source>Skip</source>
         <target>Přeskočit</target>
         <note>Button to skip onboarding in Focus</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Description">
         <source>Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times.</source>
         <target>Anonymní prohlížení dostalo nový rozměr. Blokuje reklamy a další obsah, který vás sleduje napříč stránkami a zpomaluje načítání.</target>
         <note>Description for the 'Welcome' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Title">
         <source>Power up your privacy</source>
         <target>Posuňte své soukromí na vyšší úroveň</target>
         <note>Title for the first panel 'Welcome' in the First Run tour.</note>
@@ -101,512 +100,512 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="About.learnMoreButton" xml:space="preserve">
+      <trans-unit id="About.learnMoreButton">
         <source>Learn more</source>
         <target>Zjistit více</target>
         <note>Button on About screen</note>
       </trans-unit>
-      <trans-unit id="About.missionLabel" xml:space="preserve">
+      <trans-unit id="About.missionLabel">
         <source>%@ is produced by Mozilla. Our mission is to foster a healthy, open Internet.</source>
         <target>%@ je vyvíjen Mozillou. Naše mise je podporovat zdravý a otevřený internet.</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet1" xml:space="preserve">
+      <trans-unit id="About.privateBullet1">
         <source>Search and browse right in the app</source>
         <target>Vyhledávejte a prohlížejte přímo v aplikaci</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet2" xml:space="preserve">
+      <trans-unit id="About.privateBullet2">
         <source>Block trackers (or update settings to allow trackers)</source>
         <target>Blokujte sledovací prvky (nebo aktualizujte nastavení pro povolení sledovacích prvků)</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet3" xml:space="preserve">
+      <trans-unit id="About.privateBullet3">
         <source>Erase to delete cookies as well as search and browsing history</source>
         <target>Pro smazání cookies a historie vyhledávání a prohlížení použijte tlačítko vymazat</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBulletHeader" xml:space="preserve">
+      <trans-unit id="About.privateBulletHeader">
         <source>Use it as a private browser:</source>
         <target>Používejte ho jako soukromý prohlížeč:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowHelp" xml:space="preserve">
+      <trans-unit id="About.rowHelp">
         <source>Help</source>
         <target>Nápověda</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowPrivacy" xml:space="preserve">
+      <trans-unit id="About.rowPrivacy">
         <source>Privacy Notice</source>
         <target>Zásady ochrany osobních údajů</target>
         <note>Link to Privacy Notice in the About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowRights" xml:space="preserve">
+      <trans-unit id="About.rowRights">
         <source>Your Rights</source>
         <target>Vaše práva</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet1" xml:space="preserve">
+      <trans-unit id="About.safariBullet1">
         <source>Block trackers for improved privacy</source>
         <target>Blokujte sledovací prvky pro zvýšení soukromí</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet2" xml:space="preserve">
+      <trans-unit id="About.safariBullet2">
         <source>Block web fonts to reduce page size</source>
         <target>Blokujte webové fonty pro zmenšení velikosti stránky</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBulletHeader" xml:space="preserve">
+      <trans-unit id="About.safariBulletHeader">
         <source>Use it as a Safari extension:</source>
         <target>Používejte ho jako rozšíření Safari:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.title" xml:space="preserve">
+      <trans-unit id="About.title">
         <source>About %@</source>
         <target>O aplikaci %@</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, takes the user to a page with information about the product. Also displayed as a header for the About page.</note>
       </trans-unit>
-      <trans-unit id="About.topLabel" xml:space="preserve">
+      <trans-unit id="About.topLabel">
         <source>%@ puts you in control.</source>
         <target>%@ vám dává kontrolu.</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Dismiss" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Dismiss">
         <source>Ok</source>
         <target>Ok</target>
         <note>Button to dismiss the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Message" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Message">
         <source>An error occured while adding the pass to Wallet. Please try again later.</source>
         <target>Při přidávání lístku do aplikace Wallet nastala chyba. Zkuste to prosím znovu později.</target>
         <note>Message of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Title" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Title">
         <source>Failed to Add Pass</source>
         <target>Přidání lístku selhalo</target>
         <note>Title of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="Authentication.reason" xml:space="preserve">
+      <trans-unit id="Authentication.reason">
         <source>Authenticate to return to %@</source>
         <target>Ověření pro návrat do aplikace %@</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID, Face ID, or passcode to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrl">
         <source>Add Custom URL</source>
         <target>Přidat vlastní URL adresu</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlError" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlError">
         <source>Double-check the URL you entered.</source>
         <target>Zkontrolujte zadanou URL adresu.</target>
         <note>Label for error state when entering an invalid URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlExample" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlExample">
         <source>Example: example.com</source>
         <target>Příklad: example.com</target>
         <note>A label displaying an example URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlLabel">
         <source>URL to add</source>
         <target>URL adresa k přidání</target>
         <note>Label for the input to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlPlaceholder" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlPlaceholder">
         <source>Paste or enter URL</source>
         <target>Vložte nebo napište URL adresu</target>
         <note>Placeholder for the input field to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlWithPlus" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlWithPlus">
         <source>+ Add Custom URL</source>
         <target>+ Přidat vlastní URL adresu</target>
         <note>Label for button to add a custom URL with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.customDescriptoin">
         <source>Add and manage custom autocomplete URLs.</source>
         <target>Přidání a správa vlastních URL adres pro automatické doplňování.</target>
         <note>Description for adding and managing custom autocomplete URLs</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.customLabel">
         <source>Custom URLs</source>
         <target>Vlastní URL adresy</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.customTitle">
         <source>CUSTOM URL LIST</source>
         <target>SEZNAM VLASTNÍCH URL ADRES</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customUrlAdded" xml:space="preserve">
+      <trans-unit id="Autocomplete.customUrlAdded">
         <source>New Custom URL added.</source>
         <target>Vlastní URL adresa přidána.</target>
         <note>Label for toast alerting a custom URL has been added</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultDescriptoin">
         <source>Enable to have %@ autocomplete over 450 popular URLs in the address bar.</source>
         <target>Po zapnutí bude %@ našeptávat více než 450 populárních URL adres.</target>
         <note>Description for enabling or disabling the default list. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultLabel">
         <source>Autocomplete</source>
         <target>Doplňovat automaticky</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultTitle">
         <source>DEFAULT URL LIST</source>
         <target>VÝCHOZÍ SEZNAM URL ADRES</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.disabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.disabled">
         <source>Disabled</source>
         <target>Zakázáno</target>
         <note>label describing URL Autocomplete as disabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.duplicateUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.duplicateUrl">
         <source>URL already exists</source>
         <target>URL adresa už existuje</target>
         <note>Label for toast alerting that the custom URL being added is a duplicate</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.emptyState" xml:space="preserve">
+      <trans-unit id="Autocomplete.emptyState">
         <source>No Custom URLs to display</source>
         <target>Žádné vlastní URL adresy k zobrazení</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.enabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.enabled">
         <source>Enabled</source>
         <target>Povoleno</target>
         <note>label describing URL Autocomplete as enabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.manageSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.manageSites">
         <source>Manage Sites</source>
         <target>Spravovat stránky</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySites" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySites">
         <source>My Sites</source>
         <target>Moje stránky</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySitesDesc" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySitesDesc">
         <source>Enable to have %@ autocomplete your favorite URLs.</source>
         <target>Povolí našeptávání vámi vybraných adres stránek.</target>
         <note>Description for adding and managing custom autocomplete URLs. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.topSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.topSites">
         <source>Top Sites</source>
         <target>Top stránky</target>
         <note>Label for enabling or disabling top sites</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.newSession" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.newSession">
         <source>New Session</source>
         <target>Nová relace</target>
         <note>Create a new session after failing a biometric check</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.reason" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.reason">
         <source>Unlock %@ when re-opening in order to prevent unauthorized access.</source>
         <target>Před návratem do %@ je vyžadování ověření jako ochrana před cizím přístupem.</target>
         <note>%@ is app name. Explanation for why the app needs access to biometric information. Prompt is only shown once when the user first tries to enable Face ID to open the app.</note>
       </trans-unit>
-      <trans-unit id="Browser.backLabel" xml:space="preserve">
+      <trans-unit id="Browser.backLabel">
         <source>Back</source>
         <target>Zpět</target>
         <note>Accessibility label for the back button</note>
       </trans-unit>
-      <trans-unit id="Browser.copyAddressLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyAddressLabel">
         <source>Copy Address</source>
         <target>Zkopírovat adresu</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.copyMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyMenuLabel">
         <source>Copy</source>
         <target>Kopírovat</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.customURLMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.customURLMenuLabel">
         <source>Add Custom URL</source>
         <target>Přidat vlastní URL adresu</target>
         <note>Custom URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.forwardLabel" xml:space="preserve">
+      <trans-unit id="Browser.forwardLabel">
         <source>Forward</source>
         <target>Vpřed</target>
         <note>Accessibility label for the forward button</note>
       </trans-unit>
-      <trans-unit id="Browser.reloadLabel" xml:space="preserve">
+      <trans-unit id="Browser.reloadLabel">
         <source>Reload</source>
         <target>Obnovit</target>
         <note>Accessibility label for the reload button</note>
       </trans-unit>
-      <trans-unit id="Browser.settingsLabel" xml:space="preserve">
+      <trans-unit id="Browser.settingsLabel">
         <source>Settings</source>
         <target>Nastavení</target>
         <note>Accessibility label for the settings button</note>
       </trans-unit>
-      <trans-unit id="Browser.shareLabel" xml:space="preserve">
+      <trans-unit id="Browser.shareLabel">
         <source>Share</source>
         <target>Sdílet</target>
         <note>Accessibility label for the share button</note>
       </trans-unit>
-      <trans-unit id="Browser.stopLabel" xml:space="preserve">
+      <trans-unit id="Browser.stopLabel">
         <source>Stop</source>
         <target>Zastavit</target>
         <note>Accessibility label for the stop button</note>
       </trans-unit>
-      <trans-unit id="Cancel" xml:space="preserve">
+      <trans-unit id="Cancel">
         <source>Cancel</source>
         <target>Zrušit</target>
         <note>Label on button to cancel edits</note>
       </trans-unit>
-      <trans-unit id="Done" xml:space="preserve">
+      <trans-unit id="Done">
         <source>Done</source>
         <target>Hotovo</target>
         <note>Label on button to complete edits</note>
       </trans-unit>
-      <trans-unit id="Edit" xml:space="preserve">
+      <trans-unit id="Edit">
         <source>Edit</source>
         <target>Upravit</target>
         <note>Label on button to allow edits</note>
       </trans-unit>
-      <trans-unit id="Error.tryAgainButton" xml:space="preserve">
+      <trans-unit id="Error.tryAgainButton">
         <source>Try again</source>
         <target>Zkusit znovu</target>
         <note>Button label to reload the error page</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.cancelTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.cancelTitle">
         <source>Cancel</source>
         <target>Zrušit</target>
         <note>Button label used for cancelling to open another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.messageTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.messageTitle">
         <source>%@ wants to open another App</source>
         <target>%@ chce otevřít jinou aplikaci</target>
         <note>Dialog title used for opening an external app from Focus. The placeholder string is the app name of either Focus or Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.openTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.openTitle">
         <source>Open</source>
         <target>Otevřít</target>
         <note>Button label for opening another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.callButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.callButton">
         <source>Call</source>
         <target>Volat</target>
         <note>Button label in tel: dialog to call a phone number. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.cancelButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.cancelButton">
         <source>Cancel</source>
         <target>Zrušit</target>
         <note>Button label in external link dialog to cancel the dialog. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.emailButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.emailButton">
         <source>Email</source>
         <target>E-mail</target>
         <note>Button label in mailto: dialog to send an email. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.messageTitleWithPlaceholder" xml:space="preserve">
+      <trans-unit id="ExternalLink.messageTitleWithPlaceholder">
         <source>You are now leaving %@.</source>
         <target>Nyní opouštíte %@.</target>
         <note>Dialog title used for Maps/App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreButton">
         <source>Open App Store</source>
         <target>Otevřít App Store</target>
         <note>Button label in App Store URL dialog to open the App Store. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreTitle" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreTitle">
         <source>%@ wants to open the App Store.</source>
         <target>%@ chce otevřít App Store.</target>
         <note>Dialog title used to open App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openMapsButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openMapsButton">
         <source>Open Maps</source>
         <target>Otevřít Mapy</target>
         <note>Button label in Maps URL dialog to open Maps. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="FindInPage.Done" xml:space="preserve">
+      <trans-unit id="FindInPage.Done">
         <source>Find in page done</source>
         <target>Hledání na stránce dokončeno</target>
         <note>Accessibility label for done button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.NextResult" xml:space="preserve">
+      <trans-unit id="FindInPage.NextResult">
         <source>Find next in page</source>
         <target>Najít další na stránce</target>
         <note>Accessibility label for next result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.PreviousResult" xml:space="preserve">
+      <trans-unit id="FindInPage.PreviousResult">
         <source>Find previous in page</source>
         <target>Najít předchozí na stránce</target>
         <note>Accessibility label for previous result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FirstRun.lastSlide.buttonLabel" xml:space="preserve">
+      <trans-unit id="FirstRun.lastSlide.buttonLabel">
         <source>OK, Got It!</source>
         <target>OK, rozumím!</target>
         <note>Label on button to dismiss first run UI</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelDescription" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelDescription">
         <source>Automatically block online trackers while you browse. Then tap to erase visited pages, searches, cookies and passwords from your device.</source>
         <target>Automaticky blokuje sledovací prvky, zatímco prohlížíte. Poté stačí klepnout pro vymazání zobrazených stránek, vyhledávání, cookies a hesel z vašeho zařízení.</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelTagline" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelTagline">
         <source>Browse like no one’s watching.</source>
         <target>Prohlížejte, jako když se nikdo nedívá.</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="Focus.handoffSyncing" xml:space="preserve">
+      <trans-unit id="Focus.handoffSyncing">
         <source>Apple Handoff is syncing</source>
         <target>Probíhá synchronizace Apple Handoff</target>
         <note>Title for the loading screen when the handoff of clipboard delays Focus launch. “Handoff” should not be localized, see https://support.apple.com/HT204681</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel1" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel1">
         <source>Automatic private browsing.</source>
         <target>Automatické anonymní prohlížení.</target>
         <note>First label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel2" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel2">
         <source>Browse. Erase. Repeat.</source>
         <target>Prohlížejte. Smažte. Opakujte.</target>
         <note>Second label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Menu.Close" xml:space="preserve">
+      <trans-unit id="Menu.Close">
         <source>Close</source>
         <target>Zavřít</target>
         <note>Button label used to close a menu that displays as a popup.</note>
       </trans-unit>
-      <trans-unit id="Open.Cancel" xml:space="preserve">
+      <trans-unit id="Open.Cancel">
         <source>Cancel</source>
         <target>Zrušit</target>
         <note>Label in share alert to cancel the alert</note>
       </trans-unit>
-      <trans-unit id="Open.Firefox" xml:space="preserve">
+      <trans-unit id="Open.Firefox">
         <source>Firefox (Private Browsing)</source>
         <target>Firefox (anonymní prohlížení)</target>
         <note>Label in share alert to open the URL in Firefox</note>
       </trans-unit>
-      <trans-unit id="Open.More" xml:space="preserve">
+      <trans-unit id="Open.More">
         <source>More</source>
         <target>Více</target>
         <note>Label in share alert to open the full system share menu</note>
       </trans-unit>
-      <trans-unit id="Open.Safari" xml:space="preserve">
+      <trans-unit id="Open.Safari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Label in share alert to open the URL in Safari</note>
       </trans-unit>
-      <trans-unit id="Request Desktop Site" xml:space="preserve">
+      <trans-unit id="Request Desktop Site">
         <source>Request Desktop Site</source>
         <target>Verze stránky pro počítač</target>
         <note>Label for button that requests the desktop version of the currently loaded website.</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsContentBlockers" xml:space="preserve">
+      <trans-unit id="Safari.instructionsContentBlockers">
         <source>Tap Safari, then select Content Blockers</source>
         <target>Klepněte na Safari a poté vyberte Blokátory obsahu</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsEnable" xml:space="preserve">
+      <trans-unit id="Safari.instructionsEnable">
         <source>Enable %@</source>
         <target>Povolte %@</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsNotEnabled" xml:space="preserve">
+      <trans-unit id="Safari.instructionsNotEnabled">
         <source>%@ is not enabled.</source>
         <target>%@ není povolen.</target>
         <note>Error label when the blocker is not enabled, shown in the intro and main app when disabled</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsOpen" xml:space="preserve">
+      <trans-unit id="Safari.instructionsOpen">
         <source>Open Settings App</source>
         <target>Otevřete Nastavení</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Save" xml:space="preserve">
+      <trans-unit id="Save">
         <source>Save</source>
         <target>Uložit</target>
         <note>Save button label</note>
       </trans-unit>
-      <trans-unit id="SearchEngine.addEngineError" xml:space="preserve">
+      <trans-unit id="SearchEngine.addEngineError">
         <source>That didn't work. Try replacing the search term with this: %s.</source>
         <target>To nezafungovalo. Zkuste nahradit hledaný výraz za „%s”.</target>
         <note>Label for error state when entering an invalid search engine URL. %s is a search term in a URL.</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptDisable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptDisable">
         <source>No</source>
         <target>Ne</target>
         <note>Label for disable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptEnable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptEnable">
         <source>Yes</source>
         <target>Ano</target>
         <note>Label for enable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptMessage" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptMessage">
         <source>To get suggestions, %@ needs to send what you type in the address bar to the search engine.</source>
         <target>K realizaci našeptávání musí %@ text napsaný do adresního řádku odesílat zvolenému vyhledávači.</target>
         <note>%@ is the name of the app (Focus / Klar). Label for search suggestions prompt message</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptTitle" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptTitle">
         <source>Show Search Suggestions?</source>
         <target>Povolit našeptávání?</target>
         <note>Title for search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButton" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButton">
         <source>Add Another Search Engine</source>
         <target>Přidat další vyhledávač</target>
         <note>Text for button to add another search engine in settings</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus">
         <source>+ Add Another Search Engine</source>
         <target>+ Přidat další vyhledávač</target>
         <note>Text for button to add another search engine in settings with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineTitle" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineTitle">
         <source>Add Search Engine</source>
         <target>Přidat vyhledávač</target>
         <note>Title on add search engine settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.InstalledSearchEngines" xml:space="preserve">
+      <trans-unit id="Settings.Search.InstalledSearchEngines">
         <source>INSTALLED SEARCH ENGINES</source>
         <target>NAINSTALOVANÉ VYHLEDÁVAČE</target>
         <note>Header for rows of installed search engines</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NameToDisplay" xml:space="preserve">
+      <trans-unit id="Settings.Search.NameToDisplay">
         <source>Name to display</source>
         <target>Zobrazovaný název</target>
         <note>Label for input field for the name of the search engine to be added</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NewSearchEngineAdded" xml:space="preserve">
+      <trans-unit id="Settings.Search.NewSearchEngineAdded">
         <source>New Search Engine Added.</source>
         <target>Nový vyhledávač byl přidán.</target>
         <note>Toast displayed after adding a search engine</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.RestoreEngine" xml:space="preserve">
+      <trans-unit id="Settings.Search.RestoreEngine">
         <source>Restore Default Search Engines</source>
         <target>Obnovit výchozí seznam vyhledávačů</target>
         <note>Label for button to bring deleted default engines back</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchEngineName" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchEngineName">
         <source>Search engine name</source>
         <target>Název vyhledávače</target>
         <note>Placeholder text for input of new search engine name</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplate" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplate">
         <source>Search string to use</source>
         <target>Řetězec používaný pro vyhledávání</target>
         <note>Label for input of search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplatePlaceholder" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplatePlaceholder">
         <source>Paste or enter search string. If necessary, replace search term with: %s.</source>
         <target>Vložte nebo zadejte výraz k vyhledání. Pokud je to nutné, nahraďte hledaný výraz za: %s.</target>
         <note>Placeholder text for input of new search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.autocompleteSection" xml:space="preserve">
+      <trans-unit id="Settings.autocompleteSection">
         <source>URL Autocomplete</source>
         <target>Automatické doplňování URL adres</target>
         <note>Title for the URL Autocomplete row</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherMessage" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherMessage">
         <source>Blocking other content trackers may break some videos and web pages.</source>
         <target>Blokování ostatních sledovacích prvků může rozbít některá videa a webové stránky.</target>
         <note>Alert message shown when toggling the Content blocker</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherNo2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherNo2">
         <source>Cancel</source>
         <target>Zrušit</target>
         <note>Button label for declining Content blocker alert</note>
@@ -615,447 +614,467 @@
         <source>Block Content Trackers</source>
         <note>Button label for accepting Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSearchSuggestion" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSearchSuggestion">
         <source>%@ will send what you type in the address bar to your search engine.</source>
         <target>%@ bude odesílat text zadávaný to adresního řádku vyhledávači.</target>
         <note>Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSendUsageData">
         <source>Mozilla strives to collect only what we need to provide and improve %@ for everyone.</source>
         <target>Mozilla sbírá jenom ty informace, které potřebuje pro další vylepšování aplikace %@.</target>
         <note>Description associated to the Send Usage Data toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.learnMore" xml:space="preserve">
+      <trans-unit id="Settings.learnMore">
         <source>Learn more.</source>
         <target>Zjistit více.</target>
         <note>Subtitle for Send Anonymous Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.rate" xml:space="preserve">
+      <trans-unit id="Settings.rate">
         <source>Rate %@</source>
         <target>Hodnocení %@</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, allows the user to leave a review for the app on the app store.</note>
       </trans-unit>
-      <trans-unit id="Settings.safariTitle" xml:space="preserve">
+      <trans-unit id="Settings.safariTitle">
         <source>SAFARI INTEGRATION</source>
         <target>INTEGRACE SE SAFARI</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.screenTitle" xml:space="preserve">
+      <trans-unit id="Settings.screenTitle">
         <source>Settings</source>
         <target>Nastavení</target>
         <note>Title for settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchLabel" xml:space="preserve">
+      <trans-unit id="Settings.searchLabel">
         <source>Search Engine</source>
         <target>Vyhledávač</target>
         <note>Label for the search engine in the search screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchSuggestions" xml:space="preserve">
+      <trans-unit id="Settings.searchSuggestions">
         <source>Get Search Suggestions</source>
         <target>Povolit našeptávání</target>
         <note>Label for the Search Suggestions toggle row</note>
       </trans-unit>
-      <trans-unit id="Settings.searchTitle2" xml:space="preserve">
+      <trans-unit id="Settings.searchTitle2">
         <source>SEARCH</source>
         <target>VYHLEDÁVÁNÍ</target>
         <note>Title for the search selection screen</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionIntegration" xml:space="preserve">
+      <trans-unit id="Settings.sectionIntegration">
         <source>INTEGRATION</source>
         <target>INTEGRACE</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionMozilla" xml:space="preserve">
+      <trans-unit id="Settings.sectionMozilla">
         <source>MOZILLA</source>
         <target>MOZILLA</target>
         <note>Section label for Mozilla toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPerformance" xml:space="preserve">
+      <trans-unit id="Settings.sectionPerformance">
         <source>PERFORMANCE</source>
         <target>VÝKON</target>
         <note>Section label for performance toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPrivacy" xml:space="preserve">
+      <trans-unit id="Settings.sectionPrivacy">
         <source>PRIVACY</source>
         <target>SOUKROMÍ</target>
         <note>Section label for privacy toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionSecurity" xml:space="preserve">
+      <trans-unit id="Settings.sectionSecurity">
         <source>SECURITY</source>
         <target>ZABEZPEČENÍ</target>
         <note>Header label for security toggles displayed in the settings menu</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAds2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAds2">
         <source>Advertising</source>
         <target>Reklama</target>
         <note>Label for the checkbox to toggle Advertising trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAnalytics2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAnalytics2">
         <source>Analytics</source>
         <target>Analytika</target>
         <note>Label for the checkbox to toggle Analytics trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockFonts" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockFonts">
         <source>Block web fonts</source>
         <target>Blokovat webové fonty</target>
         <note>Label for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockOther2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockOther2">
         <source>Content</source>
         <target>Obsah</target>
         <note>Label for the checkbox to toggle Other trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockSocial2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockSocial2">
         <source>Social</source>
         <target>Sociální sítě</target>
         <note>Label for the checkbox to toggle Social trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceID" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceID">
         <source>Use Face ID to unlock app</source>
         <target>Použít Face ID pro odemčení aplikace</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceIDDescription">
         <source>Face ID can unlock %@ if a URL is already open in the app</source>
         <target>Pokud je otevřena nějaká stránka, pro odemčení bude %@ potřeba Face ID</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Face ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleHomeScreenTips" xml:space="preserve">
+      <trans-unit id="Settings.toggleHomeScreenTips">
         <source>Show home screen tips</source>
         <target>Zobrazovat tipy na domovské stránce</target>
         <note>Show home screen tips toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleOtherSubtitle" xml:space="preserve">
+      <trans-unit id="Settings.toggleOtherSubtitle">
         <source>May break some videos and Web pages</source>
         <target>Může rozbít některá videa a webové stránky</target>
         <note>Label subtitle for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSafari" xml:space="preserve">
+      <trans-unit id="Settings.toggleSafari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Safari toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.toggleSendUsageData">
         <source>Send usage data</source>
         <target>Odesílat údaje o používání</target>
         <note>Label for Send Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchID" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchID">
         <source>Use Touch ID to unlock app</source>
         <target>Použít Touch ID pro odemčení aplikace</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchIDDescription">
         <source>Touch ID can unlock %@ if a URL is already open in the app</source>
         <target>Pokud je otevřena nějaká stránka, pro odemčení bude %@ potřeba Touch ID</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Touch ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOff" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOff">
         <source>Off</source>
         <target>Vypnuto</target>
         <note>Status off for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOn" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOn">
         <source>On</source>
         <target>Zapnuto</target>
         <note>Status on for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.whatsNewTitle" xml:space="preserve">
+      <trans-unit id="Settings.whatsNewTitle">
         <source>What’s New</source>
         <target>Co je nového</target>
         <note>Title for What's new screen</note>
       </trans-unit>
-      <trans-unit id="Settinsg.siriShortcutsTitle" xml:space="preserve">
+      <trans-unit id="Settinsg.siriShortcutsTitle">
         <source>SIRI SHORTCUTS</source>
         <target>ZKRATKY PRO SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.FindInPage" xml:space="preserve">
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Najít na stránce</target>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.GetFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.GetFirefox">
         <source>Get the Firefox App</source>
         <target>Získat Firefox</target>
         <note>Text for the share menu option when a user wants to open a page in Firefox but doesn’t have it installed. This string will not wrap in the interface. Instead, it will truncate. To prevent this, please keep the localized string to 18 or fewer characters. If your string runs longer than 18 characters, you can use 'Get Firefox' as the basis for your string. However, if at all possible, we’d like to signal to the user that they will be going to the App Store and installing the application from there. That is why we are using Get and App in the en-US string.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.PageActions" xml:space="preserve">
+      <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <target>Akce stránky</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestDesktop" xml:space="preserve">
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
         <target>Verze stránky pro počítač</target>
         <note>Text for the share menu option when a user wants to reload the site as a desktop</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestMobile" xml:space="preserve">
+      <trans-unit id="ShareMenu.RequestMobile">
         <source>Request Mobile Site</source>
         <target>Mobilní verze stránky</target>
         <note>Text for the share menu option when a user wants to reload the site as a mobile device</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenChrome" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenChrome">
         <source>Open in Chrome</source>
         <target>Otevřít v Chrome</target>
         <note>Text for the share menu option when a user wants to open the current website in the Chrome app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenFirefox">
         <source>Open in Firefox</source>
         <target>Otevřít ve Firefoxu</target>
         <note>Text for the share menu option when a user wants to open the current website in the Firefox app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenSafari" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenSafari">
         <source>Open in Safari</source>
         <target>Otevřít v Safari</target>
         <note>Text for the share menu option when a user wants to open the current website in the Safari app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.SharePage" xml:space="preserve">
+      <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <target>Sdílet stránku s...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
       </trans-unit>
-      <trans-unit id="Siri.add" xml:space="preserve">
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
+      </trans-unit>
+      <trans-unit id="Siri.add">
         <source>Add</source>
         <target>Přidat</target>
         <note>Button to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.addTo" xml:space="preserve">
+      <trans-unit id="Siri.addTo">
         <source>Add to Siri</source>
         <target>Přidat do Siri</target>
         <note>Button to add a specified shortcut option to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.editOpenUrl" xml:space="preserve">
+      <trans-unit id="Siri.editOpenUrl">
         <source>Re-Record or Delete Shortcut</source>
         <target>Znovu nahrát nebo smazat zkratku</target>
         <note>Label for button to edit the Siri phrase or delete the Siri functionality.</note>
       </trans-unit>
-      <trans-unit id="Siri.erase" xml:space="preserve">
+      <trans-unit id="Siri.erase">
         <source>Erase</source>
         <target>Vymazat</target>
         <note>Title of option in settings to set up Siri to erase</note>
       </trans-unit>
-      <trans-unit id="Siri.eraseAndOpen" xml:space="preserve">
+      <trans-unit id="Siri.eraseAndOpen">
         <source>Erase &amp; Open</source>
         <target>Vymazat a otevřít</target>
         <note>Title of option in settings to set up Siri to erase and then open the app.</note>
       </trans-unit>
-      <trans-unit id="Siri.favoriteUrl" xml:space="preserve">
+      <trans-unit id="Siri.favoriteUrl">
         <source>Open Favorite Site</source>
         <target>Otevřít oblíbenou stránku</target>
         <note>Title for screen to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.openURL" xml:space="preserve">
+      <trans-unit id="Siri.openURL">
         <source>Open Favorite Site</source>
         <target>Otevřít oblíbenou stránku</target>
         <note>Title of option in settings to set up Siri to open a specified URL in Focus/Klar.</note>
       </trans-unit>
-      <trans-unit id="Siri.urlToOpen" xml:space="preserve">
+      <trans-unit id="Siri.urlToOpen">
         <source>URL to open</source>
         <target>Otevřít URL</target>
         <note>Label for input to set a favorite URL to be opened by Siri.</note>
       </trans-unit>
-      <trans-unit id="URL.addToAutocompleteLabel" xml:space="preserve">
+      <trans-unit id="URL.addToAutocompleteLabel">
         <source>Add link to autocomplete</source>
         <target>Přidat tuto stránku mezi našeptávané</target>
         <note>Label displayed for button used as a shortcut to add a link to the list of URLs to autocomplete.</note>
       </trans-unit>
-      <trans-unit id="URL.cancelLabel" xml:space="preserve">
+      <trans-unit id="URL.cancelLabel">
         <source>Cancel</source>
         <target>Zrušit</target>
         <note>Label for cancel button shown when entering a URL or search</note>
       </trans-unit>
-      <trans-unit id="URL.contextMenu" xml:space="preserve">
+      <trans-unit id="URL.contextMenu">
         <source>Paste &amp; Go</source>
         <target>Vložit a přejít</target>
         <note>Text for the URL context menu when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.eraseButtonLabel" xml:space="preserve">
+      <trans-unit id="URL.eraseButtonLabel">
         <source>ERASE</source>
         <target>VYMAZAT</target>
         <note>Erase button in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.eraseMessageLabel2" xml:space="preserve">
+      <trans-unit id="URL.eraseMessageLabel2">
         <source>Browsing history cleared</source>
         <target>Historie prohlížení vymazána</target>
         <note>Message shown after pressing the Erase button</note>
       </trans-unit>
-      <trans-unit id="URL.findOnPageLabel" xml:space="preserve">
+      <trans-unit id="URL.findOnPageLabel">
         <source>Find in page: %@</source>
         <target>Najít na stránce: %@</target>
         <note>Label displayed for find in page button when typing in the URL Bar. %@ is any text the user has typed into the URL bar that they want to find on the current page.</note>
       </trans-unit>
-      <trans-unit id="URL.paste" xml:space="preserve">
+      <trans-unit id="URL.paste">
         <source>Paste</source>
         <target>Vložit</target>
         <note>Text for a menu displayed from the bottom of the screen when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.placeholderText" xml:space="preserve">
+      <trans-unit id="URL.placeholderText">
         <source>Search or enter address</source>
         <target>Zadejte adresu nebo dotaz pro vyhledávač</target>
         <note>Placeholder text shown in the URL bar before the user navigates to a page</note>
       </trans-unit>
-      <trans-unit id="URL.searchLabel" xml:space="preserve">
+      <trans-unit id="URL.searchLabel">
         <source>Search for %@</source>
         <target>Vyhledat %@</target>
         <note>Label displayed for search button when typing in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="URL.trackersBlockedLabel">
         <source>Trackers blocked</source>
         <target>Zablokováno sledovacích prvků</target>
         <note>Text for the URL bar showing the number of trackers blocked on a webpage.</note>
       </trans-unit>
-      <trans-unit id="actionSheet.openIn" xml:space="preserve">
+      <trans-unit id="actionSheet.openIn">
         <source>Open in %@</source>
         <target>Otevřít v aplikaci %@</target>
         <note>Title for action sheet item to open the current page in another application. Placeholder is the name of the application to open the current page.</note>
       </trans-unit>
-      <trans-unit id="browser.copyAddressToast" xml:space="preserve">
+      <trans-unit id="browser.copyAddressToast">
         <source>URL Copied To Clipboard</source>
         <target>URL adresa zkopírována do schránky</target>
         <note>Toast displayed after a URL has been copied to the clipboard</note>
       </trans-unit>
-      <trans-unit id="browserShortcutDescription.selectLocationBar" xml:space="preserve">
+      <trans-unit id="browserShortcutDescription.selectLocationBar">
         <source>Select Location Bar</source>
         <target>Zvolit adresní řádek</target>
         <note>Label to display in the Discoverability overlay for keyboard shortcuts</note>
       </trans-unit>
-      <trans-unit id="contextMenu.clipboardLink" xml:space="preserve">
+      <trans-unit id="contextMenu.clipboardLink">
         <source>Link you copied: %@</source>
         <target>Zkopírovaný odkaz: %@</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.copyImageTitle">
         <source>Copy Image</source>
         <target>Kopírovat obrázek</target>
         <note>Text for the context menu when a user wants to copy an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyLink" xml:space="preserve">
+      <trans-unit id="contextMenu.copyLink">
         <source>Copy Link</source>
         <target>Zkopírovat odkaz</target>
         <note>Text for the context menu when a user wants to copy a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.linkCopied" xml:space="preserve">
+      <trans-unit id="contextMenu.linkCopied">
         <source>Link you copied: </source>
         <target>Zkopírovaný odkaz:</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.saveImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.saveImageTitle">
         <source>Save Image</source>
         <target>Uložit obrázek</target>
         <note>Text for the context menu when a user wants to save an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.shareLinkTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.shareLinkTitle">
         <source>Share Link</source>
         <target>Sdílet odkaz</target>
         <note>Text for the context menu when a user wants to share a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="externalAppLinkWithAppName.messageTitle" xml:space="preserve">
+      <trans-unit id="externalAppLinkWithAppName.messageTitle">
         <source>%1$@ wants to open %2$@</source>
         <target>%1$@ chce otevřít %2$@</target>
         <note>Dialog title used for opening an external app from Focus. First placeholder string is the app name of either Focus or Klar and the second placeholder string specifies the app it wants to open.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.description" xml:space="preserve">
+      <trans-unit id="photosPermission.description">
         <source>This lets you save images to your Camera Roll</source>
         <target>Toto vám dovolí ukládat obrázky do složky fotografií</target>
         <note>Description for dialog used for requesting a user to enable access to Photos.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.openSettings" xml:space="preserve">
+      <trans-unit id="photosPermission.openSettings">
         <source>Open Settings</source>
         <target>Otevřít Nastavení</target>
         <note>Title for button that takes the user to system settings</note>
       </trans-unit>
-      <trans-unit id="photosPermission.title" xml:space="preserve">
+      <trans-unit id="photosPermission.title">
         <source>“%@” Would Like to Access Your Photos</source>
         <target>„%@“ žádá o přístup k vašim fotkám</target>
         <note>Dialog title used for requesting a user to enable access to Photos. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="settings.Search.SearchTemplateExample" xml:space="preserve">
+      <trans-unit id="settings.Search.SearchTemplateExample">
         <source>Example: searchengineexample.com/search/?q=%s</source>
         <target>Příklad: vyhledavac.example.com/search/?q=%s</target>
         <note>Text displayed as an example of the template to add a search engine.</note>
       </trans-unit>
-      <trans-unit id="share" xml:space="preserve">
+      <trans-unit id="share">
         <source>Share</source>
         <target>Sdílet</target>
         <note>Text for a share button</note>
       </trans-unit>
-      <trans-unit id="shareMenu.copyAddress" xml:space="preserve">
+      <trans-unit id="shareMenu.copyAddress">
         <source>Copy Address</source>
         <target>Zkopírovat adresu</target>
         <note>Text for the share menu when a user wants to copy a URL.</note>
       </trans-unit>
-      <trans-unit id="touchId.reason" xml:space="preserve">
+      <trans-unit id="touchId.reason">
         <source>Use Touch ID to return to %@</source>
         <target>Pro návrat do aplikace %@ použijte Touch ID</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.adTrackersLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.adTrackersLabel">
         <source>Ad trackers</source>
         <target>Sledující reklamy</target>
         <note>Label for ad trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.analyticTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.analyticTrackerLabel">
         <source>Analytic trackers</source>
         <target>Sledující analytické nástroje</target>
         <note>label for analytic trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.contentTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>
         <target>Sledující obsah</target>
         <note>label for content trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.disabledLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.disabledLabel">
         <source>Tracking Protection off</source>
         <target>Ochrana proti sledování je vypnuta</target>
         <note>text showing the tracking protection is disabled.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.label" xml:space="preserve">
+      <trans-unit id="trackingProtection.label">
         <source>Tracking Protection</source>
         <target>Ochrana proti sledování</target>
         <note>Title for the tracking settings page to change what trackers are blocked.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.labelDescription" xml:space="preserve">
+      <trans-unit id="trackingProtection.labelDescription">
         <source>Turning this off may fix some site problems</source>
         <target>Vypnutí této funkce může vyřešit některé problémy se stránkami</target>
         <note>Description/subtitle for the tracking protection label.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.learnMore" xml:space="preserve">
+      <trans-unit id="trackingProtection.learnMore">
         <source>Learn More</source>
         <target>Zjistit více</target>
         <note>Text for the button to learn more about Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.moreSettings" xml:space="preserve">
+      <trans-unit id="trackingProtection.moreSettings">
         <source>More Settings</source>
         <target>Další nastavení</target>
         <note>Text for the button that closes the Shield Data and opens the regular Settings screen.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.socialTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.socialTrackerLabel">
         <source>Social trackers</source>
         <target>Sledující soc. sítě</target>
         <note>label for social trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOff" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOff">
         <source>Protections are OFF for this session</source>
         <target>Ochrana je v této relaci vypnuta</target>
         <note>Text for the status off from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOn" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOn">
         <source>Protections are ON for this session</source>
         <target>Ochrana je v této relaci zapnuta</target>
         <note>Text for the status on from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleDescription1" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleDescription1">
         <source>Disable until you close %@ or tap ERASE.</source>
         <target>Zakázat, dokud nezavřete aplikaci %@ nebo nekliknete na VYMAZAT.</target>
         <note>Description for the tracking protection toggle. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleLabel2">
         <source>Enhanced Tracking Protection</source>
         <target>Rozšířená ochrana proti sledování</target>
         <note>Text for the toggle that enables/disables tracking protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackerDescriptionLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackerDescriptionLabel2">
         <source>Keep your data to yourself. %@ protects you from many of the most common trackers that follow what you do online.</source>
         <target>%@ vás chrání před nejběžnějšími sledovacími prvky, které sbírají informace o tom, co děláte na internetu.</target>
         <note>General description of tracking protection settings, which is displayed underneath the trackers preferences in Settings. Placeholder is either Firefox Focus or Firefox Klar</note>
@@ -1070,12 +1089,12 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Blockzilla/Settings.bundle/en.lproj/Root.strings" datatype="plaintext" source-language="en" target-language="cs">
+  <file original="Blockzilla/Settings.bundle/en.lproj/Root.strings" source-language="en" target-language="cs" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="SettingsBundle.Licenses" xml:space="preserve">
+      <trans-unit id="SettingsBundle.Licenses">
         <source>Licenses</source>
         <target>Licence</target>
         <note>The title of the Licenses setting in the settings that Focus shows in the global iOS Settings app.</note>
@@ -1083,3 +1102,4 @@
     </body>
   </file>
 </xliff>
+

--- a/cy/focus-ios.xliff
+++ b/cy/focus-ios.xliff
@@ -1,36 +1,35 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Blockzilla/en.lproj/InfoPlist.strings" source-language="en" target-language="cy" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="NSCameraUsageDescription" xml:space="preserve">
+      <trans-unit id="NSCameraUsageDescription">
         <source>This lets you take and upload photos.</source>
         <target>Mae hyn yn caniatáu i chi gymryd lluniau a'u llwytho.</target>
         <note>Privacy - Camera Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSFaceIDUsageDescription" xml:space="preserve">
+      <trans-unit id="NSFaceIDUsageDescription">
         <source>This lets you unlock the app.</source>
         <target>Mae hwn yn eich galluogi i ddatgloi'r ap.</target>
         <note>Privacy - Face ID Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSLocationWhenInUseUsageDescription" xml:space="preserve">
+      <trans-unit id="NSLocationWhenInUseUsageDescription">
         <source>Websites you visit may request your location.</source>
         <target>Efallai y bydd gwefannau rydych yn ymweld â nhw'n gofyn am eich lleoliad.</target>
         <note>Privacy - Location When In Use Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSMicrophoneUsageDescription" xml:space="preserve">
+      <trans-unit id="NSMicrophoneUsageDescription">
         <source>This lets you take and upload videos.</source>
         <target>Mae hyn yn caniatáu i chi gymryd a llwytho fideos.</target>
         <note>Privacy - Microphone Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSPhotoLibraryAddUsageDescription" xml:space="preserve">
+      <trans-unit id="NSPhotoLibraryAddUsageDescription">
         <source>This lets you save and upload photos.</source>
         <target>Mae hyn yn caniatáu i chi gadw a llwytho lluniau.</target>
         <note>Privacy - Photo Library Additions Usage Description</note>
       </trans-unit>
-      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen" xml:space="preserve">
+      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen">
         <source>Erase and Open</source>
         <target>Dileu ac Agor</target>
         <note>This is the menu item that appears when you long press the Focus icon on the phone home screen.</note>
@@ -42,7 +41,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intents.Erase.Title" xml:space="preserve">
+      <trans-unit id="Intents.Erase.Title">
         <source>Erase</source>
         <target>Dileu</target>
         <note>Title of the Erase intent.</note>
@@ -54,42 +53,42 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intro.Slides.History.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Description">
         <source>Clear your entire browsing session history, passwords, cookies anytime with a single tap.</source>
         <target>Cliriwch hanes pori, cyfrineiriau, cwcis eich sesiwn unrhyw bryd gydag un cyffyrddiad.</target>
         <note>Description for the 'History' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.History.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Title">
         <source>Your history is history</source>
         <target>Dyna ddiwedd eich hanes</target>
         <note>Title for the third  panel 'History' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Next.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Next.Button">
         <source>Next</source>
         <target>Nesaf</target>
         <note>Button to go to the next card in Focus onboarding.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Description">
         <source>Searching for something different? Choose a different search engine.</source>
         <target>Chwilio am rywbeth gwahanol? Dewiswch beiriant chwilio arall.</target>
         <note>Description for the 'Favorite Search Engine' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Title">
         <source>Your search, your way</source>
         <target>Chwilio, cynhwysfawr</target>
         <note>Title for the second  panel 'Search' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Skip.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Skip.Button">
         <source>Skip</source>
         <target>Hepgor</target>
         <note>Button to skip onboarding in Focus</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Description">
         <source>Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times.</source>
         <target>Cymrwch bori preifat i'r lefel nesaf. Rhwystrwch hysbysebion a chynnwys arall sy'n gallu'ch tracio ar draws wefannau ac arafu amserau llwytho tudalennau.</target>
         <note>Description for the 'Welcome' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Title">
         <source>Power up your privacy</source>
         <target>Cryfhewch eich preifatrwydd</target>
         <note>Title for the first panel 'Welcome' in the First Run tour.</note>
@@ -101,972 +100,992 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="About.learnMoreButton" xml:space="preserve">
+      <trans-unit id="About.learnMoreButton">
         <source>Learn more</source>
         <target>Dysgu rhagor</target>
         <note>Button on About screen</note>
       </trans-unit>
-      <trans-unit id="About.missionLabel" xml:space="preserve">
+      <trans-unit id="About.missionLabel">
         <source>%@ is produced by Mozilla. Our mission is to foster a healthy, open Internet.</source>
         <target>Mae %@ yn cael ei gynhyrchu gan Mozilla. Ein amcan yw hyrwyddo Rhyngrwyd iach ac agored.</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet1" xml:space="preserve">
+      <trans-unit id="About.privateBullet1">
         <source>Search and browse right in the app</source>
         <target>Chwilio a phori o fewn yr ap</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet2" xml:space="preserve">
+      <trans-unit id="About.privateBullet2">
         <source>Block trackers (or update settings to allow trackers)</source>
         <target>Rhwystro tracwyr (neu ddiweddaru'r gosodiadau i ganiatáu tracwyr)</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet3" xml:space="preserve">
+      <trans-unit id="About.privateBullet3">
         <source>Erase to delete cookies as well as search and browsing history</source>
         <target>Dileu er mwyn dileu cwcis yn ogystal â hanes chwilio a phori</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBulletHeader" xml:space="preserve">
+      <trans-unit id="About.privateBulletHeader">
         <source>Use it as a private browser:</source>
         <target>Ei ddefnyddio fel porwr preifat:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowHelp" xml:space="preserve">
+      <trans-unit id="About.rowHelp">
         <source>Help</source>
         <target>Cymorth</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowPrivacy" xml:space="preserve">
+      <trans-unit id="About.rowPrivacy">
         <source>Privacy Notice</source>
         <target>Hysbysiad Preifatrwydd</target>
         <note>Link to Privacy Notice in the About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowRights" xml:space="preserve">
+      <trans-unit id="About.rowRights">
         <source>Your Rights</source>
         <target>Eich Hawliau</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet1" xml:space="preserve">
+      <trans-unit id="About.safariBullet1">
         <source>Block trackers for improved privacy</source>
         <target>Rhwystro tracwyr ar gyfer gwell preifatrwydd</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet2" xml:space="preserve">
+      <trans-unit id="About.safariBullet2">
         <source>Block web fonts to reduce page size</source>
         <target>Rhwystro ffontiau Gwe i leihau maint tudalen</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBulletHeader" xml:space="preserve">
+      <trans-unit id="About.safariBulletHeader">
         <source>Use it as a Safari extension:</source>
         <target>Ei ddefnyddio fel estyniad Safari:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.title" xml:space="preserve">
+      <trans-unit id="About.title">
         <source>About %@</source>
         <target>Ynghylch %@</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, takes the user to a page with information about the product. Also displayed as a header for the About page.</note>
       </trans-unit>
-      <trans-unit id="About.topLabel" xml:space="preserve">
+      <trans-unit id="About.topLabel">
         <source>%@ puts you in control.</source>
         <target>Chi sy'n rheoli gyda %@.</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Dismiss" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Dismiss">
         <source>Ok</source>
         <target>Iawn</target>
         <note>Button to dismiss the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Message" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Message">
         <source>An error occured while adding the pass to Wallet. Please try again later.</source>
         <target>Digwyddodd gwall wrth ychwanegu'r tocyn i Wallet. Ceisiwch eto'n hwyrach.</target>
         <note>Message of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Title" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Title">
         <source>Failed to Add Pass</source>
         <target>Wedi methu Ychwanegu Pas</target>
         <note>Title of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="Authentication.reason" xml:space="preserve">
+      <trans-unit id="Authentication.reason">
         <source>Authenticate to return to %@</source>
         <target>Dilysu i ddychwelyd i %@</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID, Face ID, or passcode to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrl">
         <source>Add Custom URL</source>
         <target>Ychwanegu URL Cyfaddas</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlError" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlError">
         <source>Double-check the URL you entered.</source>
         <target>Gwiriwch yr URL rydych wedi ei roi.</target>
         <note>Label for error state when entering an invalid URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlExample" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlExample">
         <source>Example: example.com</source>
         <target>Esiampl: example.com</target>
         <note>A label displaying an example URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlLabel">
         <source>URL to add</source>
         <target>URLau i'w hychwanegu</target>
         <note>Label for the input to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlPlaceholder" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlPlaceholder">
         <source>Paste or enter URL</source>
         <target>Gludo neu rhoi URL</target>
         <note>Placeholder for the input field to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlWithPlus" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlWithPlus">
         <source>+ Add Custom URL</source>
         <target>+ Ychwanegu URL cyfaddas</target>
         <note>Label for button to add a custom URL with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.customDescriptoin">
         <source>Add and manage custom autocomplete URLs.</source>
         <target>Ychwanegu a rheoli URLs awtogwblhau cyfaddas.</target>
         <note>Description for adding and managing custom autocomplete URLs</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.customLabel">
         <source>Custom URLs</source>
         <target>URLau cyfaddas</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.customTitle">
         <source>CUSTOM URL LIST</source>
         <target>RHESTR URL CYFADDAS</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customUrlAdded" xml:space="preserve">
+      <trans-unit id="Autocomplete.customUrlAdded">
         <source>New Custom URL added.</source>
         <target>URL Cyfaddas Newydd wedi ei Ychwanegu.</target>
         <note>Label for toast alerting a custom URL has been added</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultDescriptoin">
         <source>Enable to have %@ autocomplete over 450 popular URLs in the address bar.</source>
         <target>Galluogi i %@ awtogwblhau dros 450 URL poblogaidd yn y bar cyfeiriad.</target>
         <note>Description for enabling or disabling the default list. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultLabel">
         <source>Autocomplete</source>
         <target>Awtogwblhau</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultTitle">
         <source>DEFAULT URL LIST</source>
         <target>RHESTR URL RHAGOSODEDIG</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.disabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.disabled">
         <source>Disabled</source>
         <target>Analluogwyd</target>
         <note>label describing URL Autocomplete as disabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.duplicateUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.duplicateUrl">
         <source>URL already exists</source>
         <target>URL eisoes yn bod</target>
         <note>Label for toast alerting that the custom URL being added is a duplicate</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.emptyState" xml:space="preserve">
+      <trans-unit id="Autocomplete.emptyState">
         <source>No Custom URLs to display</source>
         <target>Dim URLau Cyfaddas i'w harddangos</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.enabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.enabled">
         <source>Enabled</source>
         <target>Galluogwyd</target>
         <note>label describing URL Autocomplete as enabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.manageSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.manageSites">
         <source>Manage Sites</source>
         <target>Rheoli gwefannau</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySites" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySites">
         <source>My Sites</source>
         <target>Fy Ngwefannau</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySitesDesc" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySitesDesc">
         <source>Enable to have %@ autocomplete your favorite URLs.</source>
         <target>Galluogi i gael %@ awtogwblhau eich hoff URLau.</target>
         <note>Description for adding and managing custom autocomplete URLs. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.topSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.topSites">
         <source>Top Sites</source>
         <target>Hoff Wefannau</target>
         <note>Label for enabling or disabling top sites</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.newSession" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.newSession">
         <source>New Session</source>
         <target>Sesiwn Newydd</target>
         <note>Create a new session after failing a biometric check</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.reason" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.reason">
         <source>Unlock %@ when re-opening in order to prevent unauthorized access.</source>
         <target>Datgloi %@ wrth ailagor er mwyn atal mynediad heb ganiatâd.</target>
         <note>%@ is app name. Explanation for why the app needs access to biometric information. Prompt is only shown once when the user first tries to enable Face ID to open the app.</note>
       </trans-unit>
-      <trans-unit id="Browser.backLabel" xml:space="preserve">
+      <trans-unit id="Browser.backLabel">
         <source>Back</source>
         <target>Nôl</target>
         <note>Accessibility label for the back button</note>
       </trans-unit>
-      <trans-unit id="Browser.copyAddressLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyAddressLabel">
         <source>Copy Address</source>
         <target>Copïo'r Cyfeiriad</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.copyMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyMenuLabel">
         <source>Copy</source>
         <target>Copïo</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.customURLMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.customURLMenuLabel">
         <source>Add Custom URL</source>
         <target>Ychwanegu URL Cyfaddas</target>
         <note>Custom URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.forwardLabel" xml:space="preserve">
+      <trans-unit id="Browser.forwardLabel">
         <source>Forward</source>
         <target>Ymlaen</target>
         <note>Accessibility label for the forward button</note>
       </trans-unit>
-      <trans-unit id="Browser.reloadLabel" xml:space="preserve">
+      <trans-unit id="Browser.reloadLabel">
         <source>Reload</source>
         <target>Ail-lwytho</target>
         <note>Accessibility label for the reload button</note>
       </trans-unit>
-      <trans-unit id="Browser.settingsLabel" xml:space="preserve">
+      <trans-unit id="Browser.settingsLabel">
         <source>Settings</source>
         <target>Gosodiadau</target>
         <note>Accessibility label for the settings button</note>
       </trans-unit>
-      <trans-unit id="Browser.shareLabel" xml:space="preserve">
+      <trans-unit id="Browser.shareLabel">
         <source>Share</source>
         <target>Rhannu</target>
         <note>Accessibility label for the share button</note>
       </trans-unit>
-      <trans-unit id="Browser.stopLabel" xml:space="preserve">
+      <trans-unit id="Browser.stopLabel">
         <source>Stop</source>
         <target>Atal</target>
         <note>Accessibility label for the stop button</note>
       </trans-unit>
-      <trans-unit id="Cancel" xml:space="preserve">
+      <trans-unit id="Cancel">
         <source>Cancel</source>
         <target>Diddymu</target>
         <note>Label on button to cancel edits</note>
       </trans-unit>
-      <trans-unit id="Done" xml:space="preserve">
+      <trans-unit id="Done">
         <source>Done</source>
         <target>Gorffen</target>
         <note>Label on button to complete edits</note>
       </trans-unit>
-      <trans-unit id="Edit" xml:space="preserve">
+      <trans-unit id="Edit">
         <source>Edit</source>
         <target>Golygu</target>
         <note>Label on button to allow edits</note>
       </trans-unit>
-      <trans-unit id="Error.tryAgainButton" xml:space="preserve">
+      <trans-unit id="Error.tryAgainButton">
         <source>Try again</source>
         <target>Ceisiwch eto</target>
         <note>Button label to reload the error page</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.cancelTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.cancelTitle">
         <source>Cancel</source>
         <target>Diddymu</target>
         <note>Button label used for cancelling to open another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.messageTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.messageTitle">
         <source>%@ wants to open another App</source>
         <target>Mae %@ eisiau agor Ap arall</target>
         <note>Dialog title used for opening an external app from Focus. The placeholder string is the app name of either Focus or Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.openTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.openTitle">
         <source>Open</source>
         <target>Agor</target>
         <note>Button label for opening another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.callButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.callButton">
         <source>Call</source>
         <target>Galw</target>
         <note>Button label in tel: dialog to call a phone number. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.cancelButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.cancelButton">
         <source>Cancel</source>
         <target>Diddymu</target>
         <note>Button label in external link dialog to cancel the dialog. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.emailButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.emailButton">
         <source>Email</source>
         <target>E-bost</target>
         <note>Button label in mailto: dialog to send an email. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.messageTitleWithPlaceholder" xml:space="preserve">
+      <trans-unit id="ExternalLink.messageTitleWithPlaceholder">
         <source>You are now leaving %@.</source>
         <target>Rydych nawr yn gadael %@.</target>
         <note>Dialog title used for Maps/App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreButton">
         <source>Open App Store</source>
         <target>Agor yr App Store</target>
         <note>Button label in App Store URL dialog to open the App Store. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreTitle" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreTitle">
         <source>%@ wants to open the App Store.</source>
         <target>Mae %@ eisiau agor yr App Store.</target>
         <note>Dialog title used to open App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openMapsButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openMapsButton">
         <source>Open Maps</source>
         <target>Agor Maps</target>
         <note>Button label in Maps URL dialog to open Maps. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="FindInPage.Done" xml:space="preserve">
+      <trans-unit id="FindInPage.Done">
         <source>Find in page done</source>
         <target>Canfod ar y dudalen gorffen</target>
         <note>Accessibility label for done button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.NextResult" xml:space="preserve">
+      <trans-unit id="FindInPage.NextResult">
         <source>Find next in page</source>
         <target>Canfod nesaf ar y dudalen</target>
         <note>Accessibility label for next result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.PreviousResult" xml:space="preserve">
+      <trans-unit id="FindInPage.PreviousResult">
         <source>Find previous in page</source>
         <target>Canfod blaenorol ar y dudalen</target>
         <note>Accessibility label for previous result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FirstRun.lastSlide.buttonLabel" xml:space="preserve">
+      <trans-unit id="FirstRun.lastSlide.buttonLabel">
         <source>OK, Got It!</source>
         <target>Iawn, Wedi deall!</target>
         <note>Label on button to dismiss first run UI</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelDescription" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelDescription">
         <source>Automatically block online trackers while you browse. Then tap to erase visited pages, searches, cookies and passwords from your device.</source>
         <target>Rhwystrwch tracwyr ar-lein yn awtomatig wrth i chi bori. Gallwch dapio i ddileu tudalennau, chwilio, cwcis a chyfrineiriau oddi ar eich dyfais.</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelTagline" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelTagline">
         <source>Browse like no one’s watching.</source>
         <target>Pori fel petai neb yn eich gwylio.</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="Focus.handoffSyncing" xml:space="preserve">
+      <trans-unit id="Focus.handoffSyncing">
         <source>Apple Handoff is syncing</source>
         <target>Mae Apple Handoff yn cydweddu</target>
         <note>Title for the loading screen when the handoff of clipboard delays Focus launch. “Handoff” should not be localized, see https://support.apple.com/HT204681</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel1" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel1">
         <source>Automatic private browsing.</source>
         <target>Pori preifat awtomatig.</target>
         <note>First label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel2" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel2">
         <source>Browse. Erase. Repeat.</source>
         <target>Pori. Dileu. Gwneud Eto.</target>
         <note>Second label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Menu.Close" xml:space="preserve">
+      <trans-unit id="Menu.Close">
         <source>Close</source>
         <target>Cau</target>
         <note>Button label used to close a menu that displays as a popup.</note>
       </trans-unit>
-      <trans-unit id="Open.Cancel" xml:space="preserve">
+      <trans-unit id="Open.Cancel">
         <source>Cancel</source>
         <target>Diddymu</target>
         <note>Label in share alert to cancel the alert</note>
       </trans-unit>
-      <trans-unit id="Open.Firefox" xml:space="preserve">
+      <trans-unit id="Open.Firefox">
         <source>Firefox (Private Browsing)</source>
         <target>Firefox (Pori Preifat)</target>
         <note>Label in share alert to open the URL in Firefox</note>
       </trans-unit>
-      <trans-unit id="Open.More" xml:space="preserve">
+      <trans-unit id="Open.More">
         <source>More</source>
         <target>Rhagor</target>
         <note>Label in share alert to open the full system share menu</note>
       </trans-unit>
-      <trans-unit id="Open.Safari" xml:space="preserve">
+      <trans-unit id="Open.Safari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Label in share alert to open the URL in Safari</note>
       </trans-unit>
-      <trans-unit id="Request Desktop Site" xml:space="preserve">
+      <trans-unit id="Request Desktop Site">
         <source>Request Desktop Site</source>
         <target>Gofyn am Wefan Lawn</target>
         <note>Label for button that requests the desktop version of the currently loaded website.</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsContentBlockers" xml:space="preserve">
+      <trans-unit id="Safari.instructionsContentBlockers">
         <source>Tap Safari, then select Content Blockers</source>
         <target>Tapiwch Safari, yna dewis Content Blockers</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsEnable" xml:space="preserve">
+      <trans-unit id="Safari.instructionsEnable">
         <source>Enable %@</source>
         <target>Galluogi %@</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsNotEnabled" xml:space="preserve">
+      <trans-unit id="Safari.instructionsNotEnabled">
         <source>%@ is not enabled.</source>
         <target>Nid yw %@ wedi ei alluogi.</target>
         <note>Error label when the blocker is not enabled, shown in the intro and main app when disabled</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsOpen" xml:space="preserve">
+      <trans-unit id="Safari.instructionsOpen">
         <source>Open Settings App</source>
         <target>Agor Gosodiadau'r Ap</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Save" xml:space="preserve">
+      <trans-unit id="Save">
         <source>Save</source>
         <target>Cadw</target>
         <note>Save button label</note>
       </trans-unit>
-      <trans-unit id="SearchEngine.addEngineError" xml:space="preserve">
+      <trans-unit id="SearchEngine.addEngineError">
         <source>That didn't work. Try replacing the search term with this: %s.</source>
         <target>Heb weithio. Ceisiwch amnewid y gair chwilio gyda : %s.</target>
         <note>Label for error state when entering an invalid search engine URL. %s is a search term in a URL.</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptDisable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptDisable">
         <source>No</source>
         <target>Na</target>
         <note>Label for disable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptEnable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptEnable">
         <source>Yes</source>
         <target>Iawn</target>
         <note>Label for enable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptMessage" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptMessage">
         <source>To get suggestions, %@ needs to send what you type in the address bar to the search engine.</source>
         <target>I gael awgrymiadau, mae %@ angen anfon yr hyn rydych chi'n ei deipio yn y bar cyfeiriad i'r peiriant chwilio.</target>
         <note>%@ is the name of the app (Focus / Klar). Label for search suggestions prompt message</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptTitle" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptTitle">
         <source>Show Search Suggestions?</source>
         <target>Dangos Awgrymiadau Chwilio?</target>
         <note>Title for search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButton" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButton">
         <source>Add Another Search Engine</source>
         <target>Ychwanegu Peiriant Chwilio Arall</target>
         <note>Text for button to add another search engine in settings</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus">
         <source>+ Add Another Search Engine</source>
         <target>+ Ychwanegu Peiriant Chwilio Arall</target>
         <note>Text for button to add another search engine in settings with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineTitle" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineTitle">
         <source>Add Search Engine</source>
         <target>Ychwanegu Peiriant Chwilio</target>
         <note>Title on add search engine settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.InstalledSearchEngines" xml:space="preserve">
+      <trans-unit id="Settings.Search.InstalledSearchEngines">
         <source>INSTALLED SEARCH ENGINES</source>
         <target>PEIRIANNAU CHWILIO WEDI'U GOSOD</target>
         <note>Header for rows of installed search engines</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NameToDisplay" xml:space="preserve">
+      <trans-unit id="Settings.Search.NameToDisplay">
         <source>Name to display</source>
         <target>Enw i'w ddangos</target>
         <note>Label for input field for the name of the search engine to be added</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NewSearchEngineAdded" xml:space="preserve">
+      <trans-unit id="Settings.Search.NewSearchEngineAdded">
         <source>New Search Engine Added.</source>
         <target>Peiriant Chwilio Newydd Wedi'i Ychwanegu.</target>
         <note>Toast displayed after adding a search engine</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.RestoreEngine" xml:space="preserve">
+      <trans-unit id="Settings.Search.RestoreEngine">
         <source>Restore Default Search Engines</source>
         <target>Adfer Peiriannau Chwilio Rhagosodedig</target>
         <note>Label for button to bring deleted default engines back</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchEngineName" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchEngineName">
         <source>Search engine name</source>
         <target>Enw peiriant chwilio</target>
         <note>Placeholder text for input of new search engine name</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplate" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplate">
         <source>Search string to use</source>
         <target>Llinyn chwilio i'w ddefnyddio</target>
         <note>Label for input of search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplatePlaceholder" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplatePlaceholder">
         <source>Paste or enter search string. If necessary, replace search term with: %s.</source>
         <target>Gludwch neu gyflwyno llinyn chwilio. Os oes angen, newidiwch y termau chwilio gyda: %s.</target>
         <note>Placeholder text for input of new search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.autocompleteSection" xml:space="preserve">
+      <trans-unit id="Settings.autocompleteSection">
         <source>URL Autocomplete</source>
         <target>Awtogwblhau URL</target>
         <note>Title for the URL Autocomplete row</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherMessage" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherMessage">
         <source>Blocking other content trackers may break some videos and web pages.</source>
         <target>Gall rwystro tracwyr cynnwys eraill dorri rhai fideos a thudalennau Gwe.</target>
         <note>Alert message shown when toggling the Content blocker</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherNo2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherNo2">
         <source>Cancel</source>
         <target>Diddymu</target>
         <note>Button label for declining Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherYes2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherYes2">
         <source>Block Content Trackers</source>
         <target>Rhwystro Tracwyr Cynnwys</target>
         <note>Button label for accepting Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSearchSuggestion" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSearchSuggestion">
         <source>%@ will send what you type in the address bar to your search engine.</source>
         <target>Bydd %@ yn anfon yr hyn rydych yn ei deipio yn y bar cyfeiriad i'ch peiriant chwilio.</target>
         <note>Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSendUsageData">
         <source>Mozilla strives to collect only what we need to provide and improve %@ for everyone.</source>
         <target>Mae Mozilla'n ceisio casglu dim ond yr hyn sydd ei angen arnom i ddarparu a gwella %@ ar gyfer pawb.</target>
         <note>Description associated to the Send Usage Data toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.learnMore" xml:space="preserve">
+      <trans-unit id="Settings.learnMore">
         <source>Learn more.</source>
         <target>Dysgu rhagor.</target>
         <note>Subtitle for Send Anonymous Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.rate" xml:space="preserve">
+      <trans-unit id="Settings.rate">
         <source>Rate %@</source>
         <target>Graddio %@</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, allows the user to leave a review for the app on the app store.</note>
       </trans-unit>
-      <trans-unit id="Settings.safariTitle" xml:space="preserve">
+      <trans-unit id="Settings.safariTitle">
         <source>SAFARI INTEGRATION</source>
         <target>SAFARI INTEGRATION</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.screenTitle" xml:space="preserve">
+      <trans-unit id="Settings.screenTitle">
         <source>Settings</source>
         <target>Gosodiadau</target>
         <note>Title for settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchLabel" xml:space="preserve">
+      <trans-unit id="Settings.searchLabel">
         <source>Search Engine</source>
         <target>Peiriant Chwilio</target>
         <note>Label for the search engine in the search screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchSuggestions" xml:space="preserve">
+      <trans-unit id="Settings.searchSuggestions">
         <source>Get Search Suggestions</source>
         <target>Derbyn Awgrymiadau Chwilio</target>
         <note>Label for the Search Suggestions toggle row</note>
       </trans-unit>
-      <trans-unit id="Settings.searchTitle2" xml:space="preserve">
+      <trans-unit id="Settings.searchTitle2">
         <source>SEARCH</source>
         <target>CHWILIO</target>
         <note>Title for the search selection screen</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionIntegration" xml:space="preserve">
+      <trans-unit id="Settings.sectionIntegration">
         <source>INTEGRATION</source>
         <target>INTEGREIDDIO</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionMozilla" xml:space="preserve">
+      <trans-unit id="Settings.sectionMozilla">
         <source>MOZILLA</source>
         <target>MOZILLA</target>
         <note>Section label for Mozilla toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPerformance" xml:space="preserve">
+      <trans-unit id="Settings.sectionPerformance">
         <source>PERFORMANCE</source>
         <target>PERFFORMIAD</target>
         <note>Section label for performance toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPrivacy" xml:space="preserve">
+      <trans-unit id="Settings.sectionPrivacy">
         <source>PRIVACY</source>
         <target>PREIFATRWYDD</target>
         <note>Section label for privacy toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionSecurity" xml:space="preserve">
+      <trans-unit id="Settings.sectionSecurity">
         <source>SECURITY</source>
         <target>DIOGELWCH</target>
         <note>Header label for security toggles displayed in the settings menu</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAds2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAds2">
         <source>Advertising</source>
         <target>Hysbysebu</target>
         <note>Label for the checkbox to toggle Advertising trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAnalytics2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAnalytics2">
         <source>Analytics</source>
         <target>Dadansoddeg</target>
         <note>Label for the checkbox to toggle Analytics trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockFonts" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockFonts">
         <source>Block web fonts</source>
         <target>Rhwystro ffontiau Gwe</target>
         <note>Label for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockOther2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockOther2">
         <source>Content</source>
         <target>Cynnwys</target>
         <note>Label for the checkbox to toggle Other trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockSocial2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockSocial2">
         <source>Social</source>
         <target>Cymdeithasol</target>
         <note>Label for the checkbox to toggle Social trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceID" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceID">
         <source>Use Face ID to unlock app</source>
         <target>Defnyddio Face ID i ddatgloi ap</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceIDDescription">
         <source>Face ID can unlock %@ if a URL is already open in the app</source>
         <target>Gall Face ID ddatgloi %@ os oes URL eisoes ar agor yn yr ap</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Face ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleHomeScreenTips" xml:space="preserve">
+      <trans-unit id="Settings.toggleHomeScreenTips">
         <source>Show home screen tips</source>
         <target>Dangos cynghorion sgrin cartref</target>
         <note>Show home screen tips toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleOtherSubtitle" xml:space="preserve">
+      <trans-unit id="Settings.toggleOtherSubtitle">
         <source>May break some videos and Web pages</source>
         <target>Gall dorri rhai fideos a thudalennau Gwe</target>
         <note>Label subtitle for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSafari" xml:space="preserve">
+      <trans-unit id="Settings.toggleSafari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Safari toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.toggleSendUsageData">
         <source>Send usage data</source>
         <target>Anfon data defnydd</target>
         <note>Label for Send Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchID" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchID">
         <source>Use Touch ID to unlock app</source>
         <target>Defnyddiwch Touch ID i ddatgloi ap</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchIDDescription">
         <source>Touch ID can unlock %@ if a URL is already open in the app</source>
         <target>Gall Touch ID ddatgloi %@ os oes URL eisoes ar agor yn yr ap</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Touch ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOff" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOff">
         <source>Off</source>
         <target>Diffodd</target>
         <note>Status off for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOn" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOn">
         <source>On</source>
         <target>Ymlaen</target>
         <note>Status on for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.whatsNewTitle" xml:space="preserve">
+      <trans-unit id="Settings.whatsNewTitle">
         <source>What’s New</source>
         <target>Be sy'n Newydd</target>
         <note>Title for What's new screen</note>
       </trans-unit>
-      <trans-unit id="Settinsg.siriShortcutsTitle" xml:space="preserve">
+      <trans-unit id="Settinsg.siriShortcutsTitle">
         <source>SIRI SHORTCUTS</source>
         <target>SIRI SHORTCUTS</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.FindInPage" xml:space="preserve">
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Canfod ar y Dudalen</target>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.GetFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.GetFirefox">
         <source>Get the Firefox App</source>
         <target>Estyn Ap Firefox</target>
         <note>Text for the share menu option when a user wants to open a page in Firefox but doesn’t have it installed. This string will not wrap in the interface. Instead, it will truncate. To prevent this, please keep the localized string to 18 or fewer characters. If your string runs longer than 18 characters, you can use 'Get Firefox' as the basis for your string. However, if at all possible, we’d like to signal to the user that they will be going to the App Store and installing the application from there. That is why we are using Get and App in the en-US string.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.PageActions" xml:space="preserve">
+      <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <target>Gweithredoedd Tudalen</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestDesktop" xml:space="preserve">
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
         <target>Gofyn am Wefan Lawn</target>
         <note>Text for the share menu option when a user wants to reload the site as a desktop</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestMobile" xml:space="preserve">
+      <trans-unit id="ShareMenu.RequestMobile">
         <source>Request Mobile Site</source>
         <target>Gofyn am Wefan Symudol</target>
         <note>Text for the share menu option when a user wants to reload the site as a mobile device</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenChrome" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenChrome">
         <source>Open in Chrome</source>
         <target>Agor yn Chrome</target>
         <note>Text for the share menu option when a user wants to open the current website in the Chrome app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenFirefox">
         <source>Open in Firefox</source>
         <target>Agor yn Firefox</target>
         <note>Text for the share menu option when a user wants to open the current website in the Firefox app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenSafari" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenSafari">
         <source>Open in Safari</source>
         <target>Agor yn Safari</target>
         <note>Text for the share menu option when a user wants to open the current website in the Safari app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.SharePage" xml:space="preserve">
+      <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <target>Rhannu Tudalen Gyda...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
       </trans-unit>
-      <trans-unit id="Siri.add" xml:space="preserve">
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
+      </trans-unit>
+      <trans-unit id="Siri.add">
         <source>Add</source>
         <target>Ychwanegu</target>
         <note>Button to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.addTo" xml:space="preserve">
+      <trans-unit id="Siri.addTo">
         <source>Add to Siri</source>
         <target>Ychwanegu i Siri</target>
         <note>Button to add a specified shortcut option to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.editOpenUrl" xml:space="preserve">
+      <trans-unit id="Siri.editOpenUrl">
         <source>Re-Record or Delete Shortcut</source>
         <target>Ail Recordio neu Ddileu Llwybr Byr</target>
         <note>Label for button to edit the Siri phrase or delete the Siri functionality.</note>
       </trans-unit>
-      <trans-unit id="Siri.erase" xml:space="preserve">
+      <trans-unit id="Siri.erase">
         <source>Erase</source>
         <target>Dileu</target>
         <note>Title of option in settings to set up Siri to erase</note>
       </trans-unit>
-      <trans-unit id="Siri.eraseAndOpen" xml:space="preserve">
+      <trans-unit id="Siri.eraseAndOpen">
         <source>Erase &amp; Open</source>
         <target>Dileu ac Agor</target>
         <note>Title of option in settings to set up Siri to erase and then open the app.</note>
       </trans-unit>
-      <trans-unit id="Siri.favoriteUrl" xml:space="preserve">
+      <trans-unit id="Siri.favoriteUrl">
         <source>Open Favorite Site</source>
         <target>Agor Hoff Wefan</target>
         <note>Title for screen to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.openURL" xml:space="preserve">
+      <trans-unit id="Siri.openURL">
         <source>Open Favorite Site</source>
         <target>Agor Hoff Wefan</target>
         <note>Title of option in settings to set up Siri to open a specified URL in Focus/Klar.</note>
       </trans-unit>
-      <trans-unit id="Siri.urlToOpen" xml:space="preserve">
+      <trans-unit id="Siri.urlToOpen">
         <source>URL to open</source>
         <target>URL i'w agor</target>
         <note>Label for input to set a favorite URL to be opened by Siri.</note>
       </trans-unit>
-      <trans-unit id="URL.addToAutocompleteLabel" xml:space="preserve">
+      <trans-unit id="URL.addToAutocompleteLabel">
         <source>Add link to autocomplete</source>
         <target>Ychwanegu dolen i awtogwblhau</target>
         <note>Label displayed for button used as a shortcut to add a link to the list of URLs to autocomplete.</note>
       </trans-unit>
-      <trans-unit id="URL.cancelLabel" xml:space="preserve">
+      <trans-unit id="URL.cancelLabel">
         <source>Cancel</source>
         <target>Diddymu</target>
         <note>Label for cancel button shown when entering a URL or search</note>
       </trans-unit>
-      <trans-unit id="URL.contextMenu" xml:space="preserve">
+      <trans-unit id="URL.contextMenu">
         <source>Paste &amp; Go</source>
         <target>Gludo a Mynd</target>
         <note>Text for the URL context menu when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.eraseButtonLabel" xml:space="preserve">
+      <trans-unit id="URL.eraseButtonLabel">
         <source>ERASE</source>
         <target>DILEU</target>
         <note>Erase button in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.eraseMessageLabel2" xml:space="preserve">
+      <trans-unit id="URL.eraseMessageLabel2">
         <source>Browsing history cleared</source>
         <target>Hanes pori wedi’i glirio</target>
         <note>Message shown after pressing the Erase button</note>
       </trans-unit>
-      <trans-unit id="URL.findOnPageLabel" xml:space="preserve">
+      <trans-unit id="URL.findOnPageLabel">
         <source>Find in page: %@</source>
         <target>Canfod ar dudalen: %@</target>
         <note>Label displayed for find in page button when typing in the URL Bar. %@ is any text the user has typed into the URL bar that they want to find on the current page.</note>
       </trans-unit>
-      <trans-unit id="URL.paste" xml:space="preserve">
+      <trans-unit id="URL.paste">
         <source>Paste</source>
         <target>Gludo</target>
         <note>Text for a menu displayed from the bottom of the screen when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.placeholderText" xml:space="preserve">
+      <trans-unit id="URL.placeholderText">
         <source>Search or enter address</source>
         <target>Chwilio neu gyfeiriad</target>
         <note>Placeholder text shown in the URL bar before the user navigates to a page</note>
       </trans-unit>
-      <trans-unit id="URL.searchLabel" xml:space="preserve">
+      <trans-unit id="URL.searchLabel">
         <source>Search for %@</source>
         <target>Chwilio am %@</target>
         <note>Label displayed for search button when typing in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="URL.trackersBlockedLabel">
         <source>Trackers blocked</source>
         <target>Rhwystro tracwyr</target>
         <note>Text for the URL bar showing the number of trackers blocked on a webpage.</note>
       </trans-unit>
-      <trans-unit id="actionSheet.openIn" xml:space="preserve">
+      <trans-unit id="actionSheet.openIn">
         <source>Open in %@</source>
         <target>Agor yn %@</target>
         <note>Title for action sheet item to open the current page in another application. Placeholder is the name of the application to open the current page.</note>
       </trans-unit>
-      <trans-unit id="browser.copyAddressToast" xml:space="preserve">
+      <trans-unit id="browser.copyAddressToast">
         <source>URL Copied To Clipboard</source>
         <target>URL Wedi ei Gopïo i'r Clipfwrdd</target>
         <note>Toast displayed after a URL has been copied to the clipboard</note>
       </trans-unit>
-      <trans-unit id="browserShortcutDescription.selectLocationBar" xml:space="preserve">
+      <trans-unit id="browserShortcutDescription.selectLocationBar">
         <source>Select Location Bar</source>
         <target>Dewiswch y Bar Lleoliad</target>
         <note>Label to display in the Discoverability overlay for keyboard shortcuts</note>
       </trans-unit>
-      <trans-unit id="contextMenu.clipboardLink" xml:space="preserve">
+      <trans-unit id="contextMenu.clipboardLink">
         <source>Link you copied: %@</source>
         <target>Dolen wedi ei gopïo: %@</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.copyImageTitle">
         <source>Copy Image</source>
         <target>Copïo'r Ddelwedd</target>
         <note>Text for the context menu when a user wants to copy an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyLink" xml:space="preserve">
+      <trans-unit id="contextMenu.copyLink">
         <source>Copy Link</source>
         <target>Copïo Dolen</target>
         <note>Text for the context menu when a user wants to copy a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.linkCopied" xml:space="preserve">
+      <trans-unit id="contextMenu.linkCopied">
         <source>Link you copied: </source>
         <target>Dolen wedi ei gopïo:</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.saveImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.saveImageTitle">
         <source>Save Image</source>
         <target>Cadw'r Ddelwedd</target>
         <note>Text for the context menu when a user wants to save an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.shareLinkTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.shareLinkTitle">
         <source>Share Link</source>
         <target>Rhannu Dolen</target>
         <note>Text for the context menu when a user wants to share a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="externalAppLinkWithAppName.messageTitle" xml:space="preserve">
+      <trans-unit id="externalAppLinkWithAppName.messageTitle">
         <source>%1$@ wants to open %2$@</source>
         <target>Mae %1$@ eisiau agor %2$@</target>
         <note>Dialog title used for opening an external app from Focus. First placeholder string is the app name of either Focus or Klar and the second placeholder string specifies the app it wants to open.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.description" xml:space="preserve">
+      <trans-unit id="photosPermission.description">
         <source>This lets you save images to your Camera Roll</source>
         <target>Mae hwn yn gadael i chi gadw delweddau i'ch Camera Roll</target>
         <note>Description for dialog used for requesting a user to enable access to Photos.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.openSettings" xml:space="preserve">
+      <trans-unit id="photosPermission.openSettings">
         <source>Open Settings</source>
         <target>Agor Gosodiadau</target>
         <note>Title for button that takes the user to system settings</note>
       </trans-unit>
-      <trans-unit id="photosPermission.title" xml:space="preserve">
+      <trans-unit id="photosPermission.title">
         <source>“%@” Would Like to Access Your Photos</source>
         <target>Hoffai “%@” Gael Mynediad at Eich Lluniau</target>
         <note>Dialog title used for requesting a user to enable access to Photos. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="settings.Search.SearchTemplateExample" xml:space="preserve">
+      <trans-unit id="settings.Search.SearchTemplateExample">
         <source>Example: searchengineexample.com/search/?q=%s</source>
         <target>Esampl: searchengineexample.com/search/?q=%s</target>
         <note>Text displayed as an example of the template to add a search engine.</note>
       </trans-unit>
-      <trans-unit id="share" xml:space="preserve">
+      <trans-unit id="share">
         <source>Share</source>
         <target>Rhannu</target>
         <note>Text for a share button</note>
       </trans-unit>
-      <trans-unit id="shareMenu.copyAddress" xml:space="preserve">
+      <trans-unit id="shareMenu.copyAddress">
         <source>Copy Address</source>
         <target>Copïo Cyfeiriad</target>
         <note>Text for the share menu when a user wants to copy a URL.</note>
       </trans-unit>
-      <trans-unit id="touchId.reason" xml:space="preserve">
+      <trans-unit id="touchId.reason">
         <source>Use Touch ID to return to %@</source>
         <target>Defnyddiwch yr ID cyffwrdd i ddychwelyd i %@</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.adTrackersLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.adTrackersLabel">
         <source>Ad trackers</source>
         <target>Tracwyr hysbysebion</target>
         <note>Label for ad trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.analyticTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.analyticTrackerLabel">
         <source>Analytic trackers</source>
         <target>Tracwyr dadansoddi</target>
         <note>label for analytic trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.contentTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>
         <target>Tracwyr cynnwys</target>
         <note>label for content trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.disabledLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.disabledLabel">
         <source>Tracking Protection off</source>
         <target>Diogelu rhag Tracio i ffwrdd</target>
         <note>text showing the tracking protection is disabled.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.label" xml:space="preserve">
+      <trans-unit id="trackingProtection.label">
         <source>Tracking Protection</source>
         <target>Diogelwch rhag Tracio</target>
         <note>Title for the tracking settings page to change what trackers are blocked.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.labelDescription" xml:space="preserve">
+      <trans-unit id="trackingProtection.labelDescription">
         <source>Turning this off may fix some site problems</source>
         <target>Gall ddiffodd hwn drwsio rhai problemau gwefan</target>
         <note>Description/subtitle for the tracking protection label.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.learnMore" xml:space="preserve">
+      <trans-unit id="trackingProtection.learnMore">
         <source>Learn More</source>
         <target>Dysgu Rhagor</target>
         <note>Text for the button to learn more about Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.moreSettings" xml:space="preserve">
+      <trans-unit id="trackingProtection.moreSettings">
         <source>More Settings</source>
         <target>Rhagor o Osodiadau</target>
         <note>Text for the button that closes the Shield Data and opens the regular Settings screen.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.socialTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.socialTrackerLabel">
         <source>Social trackers</source>
         <target>Tracwyr cymdeithasol</target>
         <note>label for social trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOff" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOff">
         <source>Protections are OFF for this session</source>
         <target>Mae diogelu I FFWRDD ar gyfer y sesiwn hon</target>
         <note>Text for the status off from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOn" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOn">
         <source>Protections are ON for this session</source>
         <target>Mae diogelu YMLAEN ar gyfer y sesiwn hon</target>
         <note>Text for the status on from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleDescription1" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleDescription1">
         <source>Disable until you close %@ or tap ERASE.</source>
         <target>Analluogi nes i chi gau %@ neu dapio ERASE.</target>
         <note>Description for the tracking protection toggle. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleLabel2">
         <source>Enhanced Tracking Protection</source>
         <target>Diogelwch Uwch Rhag Tracio</target>
         <note>Text for the toggle that enables/disables tracking protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackerDescriptionLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackerDescriptionLabel2">
         <source>Keep your data to yourself. %@ protects you from many of the most common trackers that follow what you do online.</source>
         <target>Cadwch eich data i chi’ch hun. Mae %@ yn eich diogelu rhag llawer o’r tracwyr mwyaf cyffredin sy’n eich dilyn ar-lein.</target>
         <note>General description of tracking protection settings, which is displayed underneath the trackers preferences in Settings. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersBlockedLabel">
         <source>Trackers blocked since %@</source>
         <target>Tracwyr wedi'u rhwystro ers %@</target>
         <note>Text for tracking protection screen showing the number of trackers blocked since the app install. The placeholder is replaced with the install date of the application.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersHeader" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersHeader">
         <source>Trackers and scripts to block</source>
         <target>Tracwyra sgriptiau i'w rhwystro</target>
         <note>Text for the header of trackers section from Tracking Protection.</note>
@@ -1078,7 +1097,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="SettingsBundle.Licenses" xml:space="preserve">
+      <trans-unit id="SettingsBundle.Licenses">
         <source>Licenses</source>
         <target>Trwyddedau</target>
         <note>The title of the Licenses setting in the settings that Focus shows in the global iOS Settings app.</note>
@@ -1086,3 +1105,4 @@
     </body>
   </file>
 </xliff>
+

--- a/da/focus-ios.xliff
+++ b/da/focus-ios.xliff
@@ -150,7 +150,6 @@
       </trans-unit>
       <trans-unit id="About.safariBullet2">
         <source>Block web fonts to reduce page size</source>
-        <target>Bloker web-fonte, så sider indlæses hurtigere</target>
         <note>Label on About screen</note>
       </trans-unit>
       <trans-unit id="About.safariBulletHeader">
@@ -597,7 +596,6 @@
       </trans-unit>
       <trans-unit id="Settings.blockOtherMessage">
         <source>Blocking other content trackers may break some videos and web pages.</source>
-        <target>Blokering af andre indholdstrackere kan forhindre visning af nogle videoer og websider.</target>
         <note>Alert message shown when toggling the Content blocker</note>
       </trans-unit>
       <trans-unit id="Settings.blockOtherNo2">
@@ -688,7 +686,6 @@
       </trans-unit>
       <trans-unit id="Settings.toggleBlockFonts">
         <source>Block web fonts</source>
-        <target>Bloker web-fonte</target>
         <note>Label for toggle on main screen</note>
       </trans-unit>
       <trans-unit id="Settings.toggleBlockOther2">
@@ -757,6 +754,10 @@
         <target>SIRI-GENVEJE</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Find på side</target>
@@ -771,6 +772,10 @@
         <source>Page Actions</source>
         <target>Sidehandlinger</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +806,10 @@
         <source>Share Page With...</source>
         <target>Del side med...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +994,14 @@
         <source>Analytic trackers</source>
         <target>Analyse-sporing</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/de/focus-ios.xliff
+++ b/de/focus-ios.xliff
@@ -1,36 +1,35 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Blockzilla/en.lproj/InfoPlist.strings" source-language="en" target-language="de" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="NSCameraUsageDescription" xml:space="preserve">
+      <trans-unit id="NSCameraUsageDescription">
         <source>This lets you take and upload photos.</source>
         <target>Hiermit können Sie Fotos machen und hochladen.</target>
         <note>Privacy - Camera Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSFaceIDUsageDescription" xml:space="preserve">
+      <trans-unit id="NSFaceIDUsageDescription">
         <source>This lets you unlock the app.</source>
         <target>Hiermit können Sie die App entsperren.</target>
         <note>Privacy - Face ID Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSLocationWhenInUseUsageDescription" xml:space="preserve">
+      <trans-unit id="NSLocationWhenInUseUsageDescription">
         <source>Websites you visit may request your location.</source>
         <target>Von Ihnen besuchte Websites können Ihren Standort abfragen.</target>
         <note>Privacy - Location When In Use Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSMicrophoneUsageDescription" xml:space="preserve">
+      <trans-unit id="NSMicrophoneUsageDescription">
         <source>This lets you take and upload videos.</source>
         <target>Hiermit können Sie Videos aufnehmen und hochladen.</target>
         <note>Privacy - Microphone Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSPhotoLibraryAddUsageDescription" xml:space="preserve">
+      <trans-unit id="NSPhotoLibraryAddUsageDescription">
         <source>This lets you save and upload photos.</source>
         <target>Hiermit können Sie Fotos speichern und hochladen.</target>
         <note>Privacy - Photo Library Additions Usage Description</note>
       </trans-unit>
-      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen" xml:space="preserve">
+      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen">
         <source>Erase and Open</source>
         <target>Löschen und öffnen</target>
         <note>This is the menu item that appears when you long press the Focus icon on the phone home screen.</note>
@@ -42,7 +41,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intents.Erase.Title" xml:space="preserve">
+      <trans-unit id="Intents.Erase.Title">
         <source>Erase</source>
         <target>Löschen</target>
         <note>Title of the Erase intent.</note>
@@ -54,42 +53,42 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intro.Slides.History.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Description">
         <source>Clear your entire browsing session history, passwords, cookies anytime with a single tap.</source>
         <target>Löschen Sie mit einer einzigen Berührung die gesamte Chronik, Passwörter und Cookies Ihrer Sitzung.</target>
         <note>Description for the 'History' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.History.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Title">
         <source>Your history is history</source>
         <target>Ihre Chronik ist Geschichte</target>
         <note>Title for the third  panel 'History' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Next.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Next.Button">
         <source>Next</source>
         <target>Weiter</target>
         <note>Button to go to the next card in Focus onboarding.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Description">
         <source>Searching for something different? Choose a different search engine.</source>
         <target>Suchen Sie etwas anderes? Wählen Sie eine andere Suchmaschine.</target>
         <note>Description for the 'Favorite Search Engine' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Title">
         <source>Your search, your way</source>
         <target>Ihre Suche, wie Sie möchten</target>
         <note>Title for the second  panel 'Search' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Skip.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Skip.Button">
         <source>Skip</source>
         <target>Überspringen</target>
         <note>Button to skip onboarding in Focus</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Description">
         <source>Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times.</source>
         <target>Privates Surfen auf einer höheren Stufe. Blockieren Sie Werbung und andere Inhalte, die Sie über Websites hinweg verfolgen können und Seitenladezeiten verlängern.</target>
         <note>Description for the 'Welcome' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Title">
         <source>Power up your privacy</source>
         <target>Stärken Sie Ihre Privatsphäre</target>
         <note>Title for the first panel 'Welcome' in the First Run tour.</note>
@@ -101,972 +100,992 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="About.learnMoreButton" xml:space="preserve">
+      <trans-unit id="About.learnMoreButton">
         <source>Learn more</source>
         <target>Mehr erfahren</target>
         <note>Button on About screen</note>
       </trans-unit>
-      <trans-unit id="About.missionLabel" xml:space="preserve">
+      <trans-unit id="About.missionLabel">
         <source>%@ is produced by Mozilla. Our mission is to foster a healthy, open Internet.</source>
         <target>%@ wird von Mozilla entwickelt. Wir setzen uns für ein gesundes, offenes Internet ein.</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet1" xml:space="preserve">
+      <trans-unit id="About.privateBullet1">
         <source>Search and browse right in the app</source>
         <target>Suchen und surfen direkt in der App</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet2" xml:space="preserve">
+      <trans-unit id="About.privateBullet2">
         <source>Block trackers (or update settings to allow trackers)</source>
         <target>Verfolger blockieren (oder Einstellungen ändern, um Verfolger zuzulassen)</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet3" xml:space="preserve">
+      <trans-unit id="About.privateBullet3">
         <source>Erase to delete cookies as well as search and browsing history</source>
         <target>Entfernen löscht Cookies sowie Such- und Surf-Chronik</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBulletHeader" xml:space="preserve">
+      <trans-unit id="About.privateBulletHeader">
         <source>Use it as a private browser:</source>
         <target>Als privaten Browser verwenden:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowHelp" xml:space="preserve">
+      <trans-unit id="About.rowHelp">
         <source>Help</source>
         <target>Hilfe</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowPrivacy" xml:space="preserve">
+      <trans-unit id="About.rowPrivacy">
         <source>Privacy Notice</source>
         <target>Datenschutzhinweis</target>
         <note>Link to Privacy Notice in the About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowRights" xml:space="preserve">
+      <trans-unit id="About.rowRights">
         <source>Your Rights</source>
         <target>Ihre Rechte</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet1" xml:space="preserve">
+      <trans-unit id="About.safariBullet1">
         <source>Block trackers for improved privacy</source>
         <target>Verfolger blockieren, um Datenschutz zu verbessern</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet2" xml:space="preserve">
+      <trans-unit id="About.safariBullet2">
         <source>Block web fonts to reduce page size</source>
         <target>Web-Schriftarten blockieren, um den zum Anzeigen der Seite benötigten Datenverkehr zu reduzieren</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBulletHeader" xml:space="preserve">
+      <trans-unit id="About.safariBulletHeader">
         <source>Use it as a Safari extension:</source>
         <target>Als Safari-Erweiterung nutzen:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.title" xml:space="preserve">
+      <trans-unit id="About.title">
         <source>About %@</source>
         <target>Über %@</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, takes the user to a page with information about the product. Also displayed as a header for the About page.</note>
       </trans-unit>
-      <trans-unit id="About.topLabel" xml:space="preserve">
+      <trans-unit id="About.topLabel">
         <source>%@ puts you in control.</source>
         <target>Mit %@ haben Sie die Kontrolle.</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Dismiss" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Dismiss">
         <source>Ok</source>
         <target>OK</target>
         <note>Button to dismiss the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Message" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Message">
         <source>An error occured while adding the pass to Wallet. Please try again later.</source>
         <target>Beim Hinzufügen der Karte zu Wallet ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut.</target>
         <note>Message of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Title" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Title">
         <source>Failed to Add Pass</source>
         <target>Fehler beim Hinzufügen der Karte</target>
         <note>Title of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="Authentication.reason" xml:space="preserve">
+      <trans-unit id="Authentication.reason">
         <source>Authenticate to return to %@</source>
         <target>Zur Rückkehr zu %@ authentifizieren</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID, Face ID, or passcode to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrl">
         <source>Add Custom URL</source>
         <target>Benutzerdefinierte Adresse hinzufügen</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlError" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlError">
         <source>Double-check the URL you entered.</source>
         <target>Überprüfen Sie die eingegebene Adresse.</target>
         <note>Label for error state when entering an invalid URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlExample" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlExample">
         <source>Example: example.com</source>
         <target>Beispiel: example.com</target>
         <note>A label displaying an example URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlLabel">
         <source>URL to add</source>
         <target>Hinzuzufügende Adresse</target>
         <note>Label for the input to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlPlaceholder" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlPlaceholder">
         <source>Paste or enter URL</source>
         <target>Adresse eingeben oder einfügen</target>
         <note>Placeholder for the input field to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlWithPlus" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlWithPlus">
         <source>+ Add Custom URL</source>
         <target>+ Benutzerdefinierte Adresse hinzufügen</target>
         <note>Label for button to add a custom URL with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.customDescriptoin">
         <source>Add and manage custom autocomplete URLs.</source>
         <target>Benutzerdefinierte Adressen für Autovervollständigung hinzufügen und verwalten.</target>
         <note>Description for adding and managing custom autocomplete URLs</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.customLabel">
         <source>Custom URLs</source>
         <target>Benutzerdefinierte Adressen</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.customTitle">
         <source>CUSTOM URL LIST</source>
         <target>LISTE BENUTZERDEFINIERTER ADRESSEN</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customUrlAdded" xml:space="preserve">
+      <trans-unit id="Autocomplete.customUrlAdded">
         <source>New Custom URL added.</source>
         <target>Neue benutzerdefinierte Adresse hinzugefügt.</target>
         <note>Label for toast alerting a custom URL has been added</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultDescriptoin">
         <source>Enable to have %@ autocomplete over 450 popular URLs in the address bar.</source>
         <target>Aktivieren, damit %@ über 450 beliebte Adressen in der Adressleiste automatisch vervollständigt.</target>
         <note>Description for enabling or disabling the default list. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultLabel">
         <source>Autocomplete</source>
         <target>Autovervollständigung</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultTitle">
         <source>DEFAULT URL LIST</source>
         <target>STANDARD-ADRESSLISTE</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.disabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.disabled">
         <source>Disabled</source>
         <target>Deaktiviert</target>
         <note>label describing URL Autocomplete as disabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.duplicateUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.duplicateUrl">
         <source>URL already exists</source>
         <target>Adresse existiert bereits</target>
         <note>Label for toast alerting that the custom URL being added is a duplicate</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.emptyState" xml:space="preserve">
+      <trans-unit id="Autocomplete.emptyState">
         <source>No Custom URLs to display</source>
         <target>Keine benutzerdefinierten Adressen zum Anzeigen</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.enabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.enabled">
         <source>Enabled</source>
         <target>Aktiviert</target>
         <note>label describing URL Autocomplete as enabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.manageSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.manageSites">
         <source>Manage Sites</source>
         <target>Websites verwalten</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySites" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySites">
         <source>My Sites</source>
         <target>Meine Websites</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySitesDesc" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySitesDesc">
         <source>Enable to have %@ autocomplete your favorite URLs.</source>
         <target>Aktivieren Sie diese Option, damit %@ Ihre Lieblingsadressen automatisch vervollständigt.</target>
         <note>Description for adding and managing custom autocomplete URLs. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.topSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.topSites">
         <source>Top Sites</source>
         <target>Meistbesuchte Seiten</target>
         <note>Label for enabling or disabling top sites</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.newSession" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.newSession">
         <source>New Session</source>
         <target>Neue Sitzung</target>
         <note>Create a new session after failing a biometric check</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.reason" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.reason">
         <source>Unlock %@ when re-opening in order to prevent unauthorized access.</source>
         <target>%@ beim erneuten Öffnen entsperren, um unbefugten Zugriff zu verhindern.</target>
         <note>%@ is app name. Explanation for why the app needs access to biometric information. Prompt is only shown once when the user first tries to enable Face ID to open the app.</note>
       </trans-unit>
-      <trans-unit id="Browser.backLabel" xml:space="preserve">
+      <trans-unit id="Browser.backLabel">
         <source>Back</source>
         <target>Zurück</target>
         <note>Accessibility label for the back button</note>
       </trans-unit>
-      <trans-unit id="Browser.copyAddressLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyAddressLabel">
         <source>Copy Address</source>
         <target>Adresse kopieren</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.copyMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyMenuLabel">
         <source>Copy</source>
         <target>Kopieren</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.customURLMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.customURLMenuLabel">
         <source>Add Custom URL</source>
         <target>Benutzerdefinierte Adresse hinzufügen</target>
         <note>Custom URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.forwardLabel" xml:space="preserve">
+      <trans-unit id="Browser.forwardLabel">
         <source>Forward</source>
         <target>Vor</target>
         <note>Accessibility label for the forward button</note>
       </trans-unit>
-      <trans-unit id="Browser.reloadLabel" xml:space="preserve">
+      <trans-unit id="Browser.reloadLabel">
         <source>Reload</source>
         <target>Neu laden</target>
         <note>Accessibility label for the reload button</note>
       </trans-unit>
-      <trans-unit id="Browser.settingsLabel" xml:space="preserve">
+      <trans-unit id="Browser.settingsLabel">
         <source>Settings</source>
         <target>Einstellungen</target>
         <note>Accessibility label for the settings button</note>
       </trans-unit>
-      <trans-unit id="Browser.shareLabel" xml:space="preserve">
+      <trans-unit id="Browser.shareLabel">
         <source>Share</source>
         <target>Teilen</target>
         <note>Accessibility label for the share button</note>
       </trans-unit>
-      <trans-unit id="Browser.stopLabel" xml:space="preserve">
+      <trans-unit id="Browser.stopLabel">
         <source>Stop</source>
         <target>Stopp</target>
         <note>Accessibility label for the stop button</note>
       </trans-unit>
-      <trans-unit id="Cancel" xml:space="preserve">
+      <trans-unit id="Cancel">
         <source>Cancel</source>
         <target>Abbrechen</target>
         <note>Label on button to cancel edits</note>
       </trans-unit>
-      <trans-unit id="Done" xml:space="preserve">
+      <trans-unit id="Done">
         <source>Done</source>
         <target>Fertig</target>
         <note>Label on button to complete edits</note>
       </trans-unit>
-      <trans-unit id="Edit" xml:space="preserve">
+      <trans-unit id="Edit">
         <source>Edit</source>
         <target>Bearbeiten</target>
         <note>Label on button to allow edits</note>
       </trans-unit>
-      <trans-unit id="Error.tryAgainButton" xml:space="preserve">
+      <trans-unit id="Error.tryAgainButton">
         <source>Try again</source>
         <target>Erneut versuchen</target>
         <note>Button label to reload the error page</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.cancelTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.cancelTitle">
         <source>Cancel</source>
         <target>Abbrechen</target>
         <note>Button label used for cancelling to open another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.messageTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.messageTitle">
         <source>%@ wants to open another App</source>
         <target>%@ möchte eine andere App öffnen</target>
         <note>Dialog title used for opening an external app from Focus. The placeholder string is the app name of either Focus or Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.openTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.openTitle">
         <source>Open</source>
         <target>Öffnen</target>
         <note>Button label for opening another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.callButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.callButton">
         <source>Call</source>
         <target>Anrufen</target>
         <note>Button label in tel: dialog to call a phone number. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.cancelButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.cancelButton">
         <source>Cancel</source>
         <target>Abbrechen</target>
         <note>Button label in external link dialog to cancel the dialog. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.emailButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.emailButton">
         <source>Email</source>
         <target>E-Mail</target>
         <note>Button label in mailto: dialog to send an email. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.messageTitleWithPlaceholder" xml:space="preserve">
+      <trans-unit id="ExternalLink.messageTitleWithPlaceholder">
         <source>You are now leaving %@.</source>
         <target>Sie verlassen jetzt %@.</target>
         <note>Dialog title used for Maps/App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreButton">
         <source>Open App Store</source>
         <target>App Store öffnen</target>
         <note>Button label in App Store URL dialog to open the App Store. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreTitle" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreTitle">
         <source>%@ wants to open the App Store.</source>
         <target>%@ möchte den App Store öffnen.</target>
         <note>Dialog title used to open App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openMapsButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openMapsButton">
         <source>Open Maps</source>
         <target>Karten öffnen</target>
         <note>Button label in Maps URL dialog to open Maps. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="FindInPage.Done" xml:space="preserve">
+      <trans-unit id="FindInPage.Done">
         <source>Find in page done</source>
         <target>„In Seite suchen“ abgeschlossen</target>
         <note>Accessibility label for done button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.NextResult" xml:space="preserve">
+      <trans-unit id="FindInPage.NextResult">
         <source>Find next in page</source>
         <target>Vorherigen Treffer in Seite suchen</target>
         <note>Accessibility label for next result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.PreviousResult" xml:space="preserve">
+      <trans-unit id="FindInPage.PreviousResult">
         <source>Find previous in page</source>
         <target>Nächsten Treffer in Seite suchen</target>
         <note>Accessibility label for previous result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FirstRun.lastSlide.buttonLabel" xml:space="preserve">
+      <trans-unit id="FirstRun.lastSlide.buttonLabel">
         <source>OK, Got It!</source>
         <target>Ok, verstanden!</target>
         <note>Label on button to dismiss first run UI</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelDescription" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelDescription">
         <source>Automatically block online trackers while you browse. Then tap to erase visited pages, searches, cookies and passwords from your device.</source>
         <target>Blockieren Sie automatisch Online-Verfolgung beim Surfen. Durch Tippen können Sie dann besuchte Seiten, Suchanfragen, Cookies und Passwörter von Ihrem Gerät löschen.</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelTagline" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelTagline">
         <source>Browse like no one’s watching.</source>
         <target>Surfen Sie, als würde niemand zusehen.</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="Focus.handoffSyncing" xml:space="preserve">
+      <trans-unit id="Focus.handoffSyncing">
         <source>Apple Handoff is syncing</source>
         <target>Apple Handoff wird synchronisiert</target>
         <note>Title for the loading screen when the handoff of clipboard delays Focus launch. “Handoff” should not be localized, see https://support.apple.com/HT204681</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel1" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel1">
         <source>Automatic private browsing.</source>
         <target>Automatischer Privater Modus.</target>
         <note>First label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel2" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel2">
         <source>Browse. Erase. Repeat.</source>
         <target>Surfen. Löschen. Wiederholen.</target>
         <note>Second label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Menu.Close" xml:space="preserve">
+      <trans-unit id="Menu.Close">
         <source>Close</source>
         <target>Schließen</target>
         <note>Button label used to close a menu that displays as a popup.</note>
       </trans-unit>
-      <trans-unit id="Open.Cancel" xml:space="preserve">
+      <trans-unit id="Open.Cancel">
         <source>Cancel</source>
         <target>Abbrechen</target>
         <note>Label in share alert to cancel the alert</note>
       </trans-unit>
-      <trans-unit id="Open.Firefox" xml:space="preserve">
+      <trans-unit id="Open.Firefox">
         <source>Firefox (Private Browsing)</source>
         <target>Firefox (Privater Modus)</target>
         <note>Label in share alert to open the URL in Firefox</note>
       </trans-unit>
-      <trans-unit id="Open.More" xml:space="preserve">
+      <trans-unit id="Open.More">
         <source>More</source>
         <target>Mehr</target>
         <note>Label in share alert to open the full system share menu</note>
       </trans-unit>
-      <trans-unit id="Open.Safari" xml:space="preserve">
+      <trans-unit id="Open.Safari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Label in share alert to open the URL in Safari</note>
       </trans-unit>
-      <trans-unit id="Request Desktop Site" xml:space="preserve">
+      <trans-unit id="Request Desktop Site">
         <source>Request Desktop Site</source>
         <target>Desktop-Website anfordern</target>
         <note>Label for button that requests the desktop version of the currently loaded website.</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsContentBlockers" xml:space="preserve">
+      <trans-unit id="Safari.instructionsContentBlockers">
         <source>Tap Safari, then select Content Blockers</source>
         <target>Tippen Sie auf „Safari“ und wählen Sie „Inhaltsblocker“</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsEnable" xml:space="preserve">
+      <trans-unit id="Safari.instructionsEnable">
         <source>Enable %@</source>
         <target>%@ aktivieren</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsNotEnabled" xml:space="preserve">
+      <trans-unit id="Safari.instructionsNotEnabled">
         <source>%@ is not enabled.</source>
         <target>%@ ist nicht aktiviert.</target>
         <note>Error label when the blocker is not enabled, shown in the intro and main app when disabled</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsOpen" xml:space="preserve">
+      <trans-unit id="Safari.instructionsOpen">
         <source>Open Settings App</source>
         <target>Einstellungs-App öffnen</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Save" xml:space="preserve">
+      <trans-unit id="Save">
         <source>Save</source>
         <target>Speichern</target>
         <note>Save button label</note>
       </trans-unit>
-      <trans-unit id="SearchEngine.addEngineError" xml:space="preserve">
+      <trans-unit id="SearchEngine.addEngineError">
         <source>That didn't work. Try replacing the search term with this: %s.</source>
         <target>Das hat nicht funktioniert. Versuchen Sie, den Suchbegriff durch Folgendes zu ersetzen: %s.</target>
         <note>Label for error state when entering an invalid search engine URL. %s is a search term in a URL.</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptDisable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptDisable">
         <source>No</source>
         <target>Nein</target>
         <note>Label for disable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptEnable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptEnable">
         <source>Yes</source>
         <target>Ja</target>
         <note>Label for enable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptMessage" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptMessage">
         <source>To get suggestions, %@ needs to send what you type in the address bar to the search engine.</source>
         <target>Um Ihnen Suchvorschläge anzuzeigen, muss %@ Ihre Eingaben in die Adressleiste an die Suchmaschine senden.</target>
         <note>%@ is the name of the app (Focus / Klar). Label for search suggestions prompt message</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptTitle" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptTitle">
         <source>Show Search Suggestions?</source>
         <target>Suchvorschläge anzeigen?</target>
         <note>Title for search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButton" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButton">
         <source>Add Another Search Engine</source>
         <target>Weitere Suchmaschine hinzufügen</target>
         <note>Text for button to add another search engine in settings</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus">
         <source>+ Add Another Search Engine</source>
         <target>+ Weitere Suchmaschine hinzufügen</target>
         <note>Text for button to add another search engine in settings with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineTitle" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineTitle">
         <source>Add Search Engine</source>
         <target>Suchmaschine hinzufügen</target>
         <note>Title on add search engine settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.InstalledSearchEngines" xml:space="preserve">
+      <trans-unit id="Settings.Search.InstalledSearchEngines">
         <source>INSTALLED SEARCH ENGINES</source>
         <target>INSTALLIERTE SUCHMASCHINEN</target>
         <note>Header for rows of installed search engines</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NameToDisplay" xml:space="preserve">
+      <trans-unit id="Settings.Search.NameToDisplay">
         <source>Name to display</source>
         <target>Anzeigename</target>
         <note>Label for input field for the name of the search engine to be added</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NewSearchEngineAdded" xml:space="preserve">
+      <trans-unit id="Settings.Search.NewSearchEngineAdded">
         <source>New Search Engine Added.</source>
         <target>Neue Suchmaschine hinzugefügt.</target>
         <note>Toast displayed after adding a search engine</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.RestoreEngine" xml:space="preserve">
+      <trans-unit id="Settings.Search.RestoreEngine">
         <source>Restore Default Search Engines</source>
         <target>Standardsuchmaschinen wiederherstellen</target>
         <note>Label for button to bring deleted default engines back</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchEngineName" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchEngineName">
         <source>Search engine name</source>
         <target>Name der Suchmaschine</target>
         <note>Placeholder text for input of new search engine name</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplate" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplate">
         <source>Search string to use</source>
         <target>Zu verwendender Such-String</target>
         <note>Label for input of search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplatePlaceholder" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplatePlaceholder">
         <source>Paste or enter search string. If necessary, replace search term with: %s.</source>
         <target>Such-String einfügen oder eingeben. Wenn nötig, ersetzen Sie den Suchbegriff mit: %s.</target>
         <note>Placeholder text for input of new search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.autocompleteSection" xml:space="preserve">
+      <trans-unit id="Settings.autocompleteSection">
         <source>URL Autocomplete</source>
         <target>Adressen-Autovervollständigung</target>
         <note>Title for the URL Autocomplete row</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherMessage" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherMessage">
         <source>Blocking other content trackers may break some videos and web pages.</source>
         <target>Blockieren von Inhaltsverfolgern kann einige Videos und Webseiten stören.</target>
         <note>Alert message shown when toggling the Content blocker</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherNo2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherNo2">
         <source>Cancel</source>
         <target>Abbrechen</target>
         <note>Button label for declining Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherYes2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherYes2">
         <source>Block Content Trackers</source>
         <target>Inhalts-Tracker blockieren</target>
         <note>Button label for accepting Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSearchSuggestion" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSearchSuggestion">
         <source>%@ will send what you type in the address bar to your search engine.</source>
         <target>%@ übermittelt Ihre Eingaben in die Adressleiste an Ihre Suchmaschine.</target>
         <note>Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSendUsageData">
         <source>Mozilla strives to collect only what we need to provide and improve %@ for everyone.</source>
         <target>Mozilla ist bestrebt, nur die Informationen zu sammeln, mit denen wir %@ anbieten und für alle Nutzer verbessern können.</target>
         <note>Description associated to the Send Usage Data toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.learnMore" xml:space="preserve">
+      <trans-unit id="Settings.learnMore">
         <source>Learn more.</source>
         <target>Weitere Informationen</target>
         <note>Subtitle for Send Anonymous Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.rate" xml:space="preserve">
+      <trans-unit id="Settings.rate">
         <source>Rate %@</source>
         <target>%@ bewerten</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, allows the user to leave a review for the app on the app store.</note>
       </trans-unit>
-      <trans-unit id="Settings.safariTitle" xml:space="preserve">
+      <trans-unit id="Settings.safariTitle">
         <source>SAFARI INTEGRATION</source>
         <target>SAFARI-INTEGRATION</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.screenTitle" xml:space="preserve">
+      <trans-unit id="Settings.screenTitle">
         <source>Settings</source>
         <target>Einstellungen</target>
         <note>Title for settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchLabel" xml:space="preserve">
+      <trans-unit id="Settings.searchLabel">
         <source>Search Engine</source>
         <target>Suchmaschine</target>
         <note>Label for the search engine in the search screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchSuggestions" xml:space="preserve">
+      <trans-unit id="Settings.searchSuggestions">
         <source>Get Search Suggestions</source>
         <target>Suchvorschläge erhalten</target>
         <note>Label for the Search Suggestions toggle row</note>
       </trans-unit>
-      <trans-unit id="Settings.searchTitle2" xml:space="preserve">
+      <trans-unit id="Settings.searchTitle2">
         <source>SEARCH</source>
         <target>SUCHE</target>
         <note>Title for the search selection screen</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionIntegration" xml:space="preserve">
+      <trans-unit id="Settings.sectionIntegration">
         <source>INTEGRATION</source>
         <target>INTEGRATION</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionMozilla" xml:space="preserve">
+      <trans-unit id="Settings.sectionMozilla">
         <source>MOZILLA</source>
         <target>MOZILLA</target>
         <note>Section label for Mozilla toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPerformance" xml:space="preserve">
+      <trans-unit id="Settings.sectionPerformance">
         <source>PERFORMANCE</source>
         <target>LEISTUNG</target>
         <note>Section label for performance toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPrivacy" xml:space="preserve">
+      <trans-unit id="Settings.sectionPrivacy">
         <source>PRIVACY</source>
         <target>DATENSCHUTZ</target>
         <note>Section label for privacy toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionSecurity" xml:space="preserve">
+      <trans-unit id="Settings.sectionSecurity">
         <source>SECURITY</source>
         <target>SICHERHEIT</target>
         <note>Header label for security toggles displayed in the settings menu</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAds2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAds2">
         <source>Advertising</source>
         <target>Werbung</target>
         <note>Label for the checkbox to toggle Advertising trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAnalytics2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAnalytics2">
         <source>Analytics</source>
         <target>Analytik</target>
         <note>Label for the checkbox to toggle Analytics trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockFonts" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockFonts">
         <source>Block web fonts</source>
         <target>Web-Schriftarten blockieren</target>
         <note>Label for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockOther2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockOther2">
         <source>Content</source>
         <target>Inhalt</target>
         <note>Label for the checkbox to toggle Other trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockSocial2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockSocial2">
         <source>Social</source>
         <target>Soziale Netzwerke</target>
         <note>Label for the checkbox to toggle Social trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceID" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceID">
         <source>Use Face ID to unlock app</source>
         <target>Face ID zum Entsperren der App verwenden</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceIDDescription">
         <source>Face ID can unlock %@ if a URL is already open in the app</source>
         <target>Face ID kann %@ entsperren, wenn bereits eine URL in der App geöffnet ist</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Face ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleHomeScreenTips" xml:space="preserve">
+      <trans-unit id="Settings.toggleHomeScreenTips">
         <source>Show home screen tips</source>
         <target>Tipps im Startbildschirm anzeigen</target>
         <note>Show home screen tips toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleOtherSubtitle" xml:space="preserve">
+      <trans-unit id="Settings.toggleOtherSubtitle">
         <source>May break some videos and Web pages</source>
         <target>Kann einige Videos und Webseiten stören</target>
         <note>Label subtitle for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSafari" xml:space="preserve">
+      <trans-unit id="Settings.toggleSafari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Safari toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.toggleSendUsageData">
         <source>Send usage data</source>
         <target>Nutzungsdaten senden</target>
         <note>Label for Send Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchID" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchID">
         <source>Use Touch ID to unlock app</source>
         <target>Touch ID zum Entsperren der App verwenden</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchIDDescription">
         <source>Touch ID can unlock %@ if a URL is already open in the app</source>
         <target>Touch ID kann %@ entsperren, wenn bereits eine URL in der App geöffnet ist</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Touch ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOff" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOff">
         <source>Off</source>
         <target>Aus</target>
         <note>Status off for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOn" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOn">
         <source>On</source>
         <target>Ein</target>
         <note>Status on for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.whatsNewTitle" xml:space="preserve">
+      <trans-unit id="Settings.whatsNewTitle">
         <source>What’s New</source>
         <target>Was ist neu</target>
         <note>Title for What's new screen</note>
       </trans-unit>
-      <trans-unit id="Settinsg.siriShortcutsTitle" xml:space="preserve">
+      <trans-unit id="Settinsg.siriShortcutsTitle">
         <source>SIRI SHORTCUTS</source>
         <target>SIRI-TASTATURKÜRZEL</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.FindInPage" xml:space="preserve">
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>In Seite suchen</target>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.GetFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.GetFirefox">
         <source>Get the Firefox App</source>
         <target>Holen Sie sich die Firefox-App</target>
         <note>Text for the share menu option when a user wants to open a page in Firefox but doesn’t have it installed. This string will not wrap in the interface. Instead, it will truncate. To prevent this, please keep the localized string to 18 or fewer characters. If your string runs longer than 18 characters, you can use 'Get Firefox' as the basis for your string. However, if at all possible, we’d like to signal to the user that they will be going to the App Store and installing the application from there. That is why we are using Get and App in the en-US string.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.PageActions" xml:space="preserve">
+      <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <target>Aktionen für Seite</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestDesktop" xml:space="preserve">
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
         <target>Desktop-Website anfordern</target>
         <note>Text for the share menu option when a user wants to reload the site as a desktop</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestMobile" xml:space="preserve">
+      <trans-unit id="ShareMenu.RequestMobile">
         <source>Request Mobile Site</source>
         <target>Mobile Website anfordern</target>
         <note>Text for the share menu option when a user wants to reload the site as a mobile device</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenChrome" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenChrome">
         <source>Open in Chrome</source>
         <target>In Chrome öffnen</target>
         <note>Text for the share menu option when a user wants to open the current website in the Chrome app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenFirefox">
         <source>Open in Firefox</source>
         <target>In Firefox öffnen</target>
         <note>Text for the share menu option when a user wants to open the current website in the Firefox app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenSafari" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenSafari">
         <source>Open in Safari</source>
         <target>In Safari öffnen</target>
         <note>Text for the share menu option when a user wants to open the current website in the Safari app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.SharePage" xml:space="preserve">
+      <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <target>Seite teilen mit…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
       </trans-unit>
-      <trans-unit id="Siri.add" xml:space="preserve">
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
+      </trans-unit>
+      <trans-unit id="Siri.add">
         <source>Add</source>
         <target>Hinzufügen</target>
         <note>Button to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.addTo" xml:space="preserve">
+      <trans-unit id="Siri.addTo">
         <source>Add to Siri</source>
         <target>Zu Siri hinzufügen</target>
         <note>Button to add a specified shortcut option to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.editOpenUrl" xml:space="preserve">
+      <trans-unit id="Siri.editOpenUrl">
         <source>Re-Record or Delete Shortcut</source>
         <target>Erneut aufzeichnen oder Tastaturkürzel löschen</target>
         <note>Label for button to edit the Siri phrase or delete the Siri functionality.</note>
       </trans-unit>
-      <trans-unit id="Siri.erase" xml:space="preserve">
+      <trans-unit id="Siri.erase">
         <source>Erase</source>
         <target>Löschen</target>
         <note>Title of option in settings to set up Siri to erase</note>
       </trans-unit>
-      <trans-unit id="Siri.eraseAndOpen" xml:space="preserve">
+      <trans-unit id="Siri.eraseAndOpen">
         <source>Erase &amp; Open</source>
         <target>Löschen &amp; öffnen</target>
         <note>Title of option in settings to set up Siri to erase and then open the app.</note>
       </trans-unit>
-      <trans-unit id="Siri.favoriteUrl" xml:space="preserve">
+      <trans-unit id="Siri.favoriteUrl">
         <source>Open Favorite Site</source>
         <target>Favoriten-Website öffnen</target>
         <note>Title for screen to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.openURL" xml:space="preserve">
+      <trans-unit id="Siri.openURL">
         <source>Open Favorite Site</source>
         <target>Favoriten-Website öffnen</target>
         <note>Title of option in settings to set up Siri to open a specified URL in Focus/Klar.</note>
       </trans-unit>
-      <trans-unit id="Siri.urlToOpen" xml:space="preserve">
+      <trans-unit id="Siri.urlToOpen">
         <source>URL to open</source>
         <target>Zu öffnende URL</target>
         <note>Label for input to set a favorite URL to be opened by Siri.</note>
       </trans-unit>
-      <trans-unit id="URL.addToAutocompleteLabel" xml:space="preserve">
+      <trans-unit id="URL.addToAutocompleteLabel">
         <source>Add link to autocomplete</source>
         <target>Link zum Autovervollständigen hinzufügen</target>
         <note>Label displayed for button used as a shortcut to add a link to the list of URLs to autocomplete.</note>
       </trans-unit>
-      <trans-unit id="URL.cancelLabel" xml:space="preserve">
+      <trans-unit id="URL.cancelLabel">
         <source>Cancel</source>
         <target>Abbrechen</target>
         <note>Label for cancel button shown when entering a URL or search</note>
       </trans-unit>
-      <trans-unit id="URL.contextMenu" xml:space="preserve">
+      <trans-unit id="URL.contextMenu">
         <source>Paste &amp; Go</source>
         <target>Einfügen &amp; Los</target>
         <note>Text for the URL context menu when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.eraseButtonLabel" xml:space="preserve">
+      <trans-unit id="URL.eraseButtonLabel">
         <source>ERASE</source>
         <target>ENTFERNEN</target>
         <note>Erase button in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.eraseMessageLabel2" xml:space="preserve">
+      <trans-unit id="URL.eraseMessageLabel2">
         <source>Browsing history cleared</source>
         <target>Surf-Chronik gelöscht</target>
         <note>Message shown after pressing the Erase button</note>
       </trans-unit>
-      <trans-unit id="URL.findOnPageLabel" xml:space="preserve">
+      <trans-unit id="URL.findOnPageLabel">
         <source>Find in page: %@</source>
         <target>In Seite suchen: %@</target>
         <note>Label displayed for find in page button when typing in the URL Bar. %@ is any text the user has typed into the URL bar that they want to find on the current page.</note>
       </trans-unit>
-      <trans-unit id="URL.paste" xml:space="preserve">
+      <trans-unit id="URL.paste">
         <source>Paste</source>
         <target>Einfügen</target>
         <note>Text for a menu displayed from the bottom of the screen when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.placeholderText" xml:space="preserve">
+      <trans-unit id="URL.placeholderText">
         <source>Search or enter address</source>
         <target>Suche oder Adresse eingeben</target>
         <note>Placeholder text shown in the URL bar before the user navigates to a page</note>
       </trans-unit>
-      <trans-unit id="URL.searchLabel" xml:space="preserve">
+      <trans-unit id="URL.searchLabel">
         <source>Search for %@</source>
         <target>Suchen nach %@</target>
         <note>Label displayed for search button when typing in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="URL.trackersBlockedLabel">
         <source>Trackers blocked</source>
         <target>blockierte Verfolger</target>
         <note>Text for the URL bar showing the number of trackers blocked on a webpage.</note>
       </trans-unit>
-      <trans-unit id="actionSheet.openIn" xml:space="preserve">
+      <trans-unit id="actionSheet.openIn">
         <source>Open in %@</source>
         <target>In %@ öffnen</target>
         <note>Title for action sheet item to open the current page in another application. Placeholder is the name of the application to open the current page.</note>
       </trans-unit>
-      <trans-unit id="browser.copyAddressToast" xml:space="preserve">
+      <trans-unit id="browser.copyAddressToast">
         <source>URL Copied To Clipboard</source>
         <target>URL in Zwischenablage kopiert</target>
         <note>Toast displayed after a URL has been copied to the clipboard</note>
       </trans-unit>
-      <trans-unit id="browserShortcutDescription.selectLocationBar" xml:space="preserve">
+      <trans-unit id="browserShortcutDescription.selectLocationBar">
         <source>Select Location Bar</source>
         <target>Adressleiste auswählen</target>
         <note>Label to display in the Discoverability overlay for keyboard shortcuts</note>
       </trans-unit>
-      <trans-unit id="contextMenu.clipboardLink" xml:space="preserve">
+      <trans-unit id="contextMenu.clipboardLink">
         <source>Link you copied: %@</source>
         <target>Von Ihnen kopierter Link: %@</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.copyImageTitle">
         <source>Copy Image</source>
         <target>Grafik kopieren</target>
         <note>Text for the context menu when a user wants to copy an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyLink" xml:space="preserve">
+      <trans-unit id="contextMenu.copyLink">
         <source>Copy Link</source>
         <target>Link kopieren</target>
         <note>Text for the context menu when a user wants to copy a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.linkCopied" xml:space="preserve">
+      <trans-unit id="contextMenu.linkCopied">
         <source>Link you copied: </source>
         <target>Von Ihnen kopierter Link:</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.saveImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.saveImageTitle">
         <source>Save Image</source>
         <target>Grafik speichern</target>
         <note>Text for the context menu when a user wants to save an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.shareLinkTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.shareLinkTitle">
         <source>Share Link</source>
         <target>Link teilen</target>
         <note>Text for the context menu when a user wants to share a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="externalAppLinkWithAppName.messageTitle" xml:space="preserve">
+      <trans-unit id="externalAppLinkWithAppName.messageTitle">
         <source>%1$@ wants to open %2$@</source>
         <target>%1$@ möchte %2$@ öffnen</target>
         <note>Dialog title used for opening an external app from Focus. First placeholder string is the app name of either Focus or Klar and the second placeholder string specifies the app it wants to open.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.description" xml:space="preserve">
+      <trans-unit id="photosPermission.description">
         <source>This lets you save images to your Camera Roll</source>
         <target>Hiermit können Sie Grafiken in Ihren Aufnahmen speichern</target>
         <note>Description for dialog used for requesting a user to enable access to Photos.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.openSettings" xml:space="preserve">
+      <trans-unit id="photosPermission.openSettings">
         <source>Open Settings</source>
         <target>Einstellungen öffnen</target>
         <note>Title for button that takes the user to system settings</note>
       </trans-unit>
-      <trans-unit id="photosPermission.title" xml:space="preserve">
+      <trans-unit id="photosPermission.title">
         <source>“%@” Would Like to Access Your Photos</source>
         <target>„%@“ möchte auf Ihre Fotos zugreifen</target>
         <note>Dialog title used for requesting a user to enable access to Photos. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="settings.Search.SearchTemplateExample" xml:space="preserve">
+      <trans-unit id="settings.Search.SearchTemplateExample">
         <source>Example: searchengineexample.com/search/?q=%s</source>
         <target>Beispiel: searchengineexample.com/search/?q=%s</target>
         <note>Text displayed as an example of the template to add a search engine.</note>
       </trans-unit>
-      <trans-unit id="share" xml:space="preserve">
+      <trans-unit id="share">
         <source>Share</source>
         <target>Teilen</target>
         <note>Text for a share button</note>
       </trans-unit>
-      <trans-unit id="shareMenu.copyAddress" xml:space="preserve">
+      <trans-unit id="shareMenu.copyAddress">
         <source>Copy Address</source>
         <target>Adresse kopieren</target>
         <note>Text for the share menu when a user wants to copy a URL.</note>
       </trans-unit>
-      <trans-unit id="touchId.reason" xml:space="preserve">
+      <trans-unit id="touchId.reason">
         <source>Use Touch ID to return to %@</source>
         <target>Verwenden Sie Touch ID, um zu %@ zurückzukehren</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.adTrackersLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.adTrackersLabel">
         <source>Ad trackers</source>
         <target>Werbe-Tracker</target>
         <note>Label for ad trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.analyticTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.analyticTrackerLabel">
         <source>Analytic trackers</source>
         <target>Analyse-Tracker</target>
         <note>label for analytic trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.contentTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>
         <target>Inhalts-Tracker</target>
         <note>label for content trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.disabledLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.disabledLabel">
         <source>Tracking Protection off</source>
         <target>Schutz vor Aktivitätenverfolgung aus</target>
         <note>text showing the tracking protection is disabled.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.label" xml:space="preserve">
+      <trans-unit id="trackingProtection.label">
         <source>Tracking Protection</source>
         <target>Schutz vor Aktivitätenverfolgung</target>
         <note>Title for the tracking settings page to change what trackers are blocked.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.labelDescription" xml:space="preserve">
+      <trans-unit id="trackingProtection.labelDescription">
         <source>Turning this off may fix some site problems</source>
         <target>Wenn Sie diese Option deaktivieren, werden möglicherweise einige Probleme mit der Website behoben</target>
         <note>Description/subtitle for the tracking protection label.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.learnMore" xml:space="preserve">
+      <trans-unit id="trackingProtection.learnMore">
         <source>Learn More</source>
         <target>Weitere Informationen</target>
         <note>Text for the button to learn more about Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.moreSettings" xml:space="preserve">
+      <trans-unit id="trackingProtection.moreSettings">
         <source>More Settings</source>
         <target>Mehr Einstellungen</target>
         <note>Text for the button that closes the Shield Data and opens the regular Settings screen.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.socialTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.socialTrackerLabel">
         <source>Social trackers</source>
         <target>Soziale Tracker</target>
         <note>label for social trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOff" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOff">
         <source>Protections are OFF for this session</source>
         <target>Der Schutz ist für diese Sitzung deaktiviert</target>
         <note>Text for the status off from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOn" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOn">
         <source>Protections are ON for this session</source>
         <target>Der Schutz ist für diese Website deaktiviert</target>
         <note>Text for the status on from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleDescription1" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleDescription1">
         <source>Disable until you close %@ or tap ERASE.</source>
         <target>Deaktivieren, bis Sie %@ schließen oder auf ENTFERNEN tippen.</target>
         <note>Description for the tracking protection toggle. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleLabel2">
         <source>Enhanced Tracking Protection</source>
         <target>Verbesserter Tracking-Schutz</target>
         <note>Text for the toggle that enables/disables tracking protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackerDescriptionLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackerDescriptionLabel2">
         <source>Keep your data to yourself. %@ protects you from many of the most common trackers that follow what you do online.</source>
         <target>Behalten Sie Ihre Daten für sich. %@ schützt Sie vor vielen der gängigsten Tracker, die Ihre Online-Aktivitäten verfolgen.</target>
         <note>General description of tracking protection settings, which is displayed underneath the trackers preferences in Settings. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersBlockedLabel">
         <source>Trackers blocked since %@</source>
         <target>Tracker blockiert seit %@</target>
         <note>Text for tracking protection screen showing the number of trackers blocked since the app install. The placeholder is replaced with the install date of the application.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersHeader" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersHeader">
         <source>Trackers and scripts to block</source>
         <target>Zu blockierende Tracker und Skripte</target>
         <note>Text for the header of trackers section from Tracking Protection.</note>
@@ -1078,7 +1097,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="SettingsBundle.Licenses" xml:space="preserve">
+      <trans-unit id="SettingsBundle.Licenses">
         <source>Licenses</source>
         <target>Lizenzen</target>
         <note>The title of the Licenses setting in the settings that Focus shows in the global iOS Settings app.</note>
@@ -1086,3 +1105,4 @@
     </body>
   </file>
 </xliff>
+

--- a/dsb/focus-ios.xliff
+++ b/dsb/focus-ios.xliff
@@ -761,6 +761,10 @@
         <target>TASTOWE SKROTCONKI SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Na boku pytaś</target>
@@ -775,6 +779,10 @@
         <source>Page Actions</source>
         <target>Akcije boka</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -805,6 +813,10 @@
         <source>Share Page With...</source>
         <target>Bok źěliś z...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -990,6 +1002,14 @@
         <source>Analytic trackers</source>
         <target>Analyzowe pśeslědowaki</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/el/focus-ios.xliff
+++ b/el/focus-ios.xliff
@@ -758,6 +758,10 @@
         <target>ΣΥΝΤΟΜΕΥΣΕΙΣ SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Εύρεση στη σελίδα</target>
@@ -772,6 +776,10 @@
         <source>Page Actions</source>
         <target>Ενέργειες σελίδας</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -802,6 +810,10 @@
         <source>Share Page With...</source>
         <target>Κοινή χρήση σελίδας με...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -986,6 +998,14 @@
         <source>Analytic trackers</source>
         <target>Αναλυτικοί ιχνηλάτες</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/en-US/focus-ios.xliff
+++ b/en-US/focus-ios.xliff
@@ -770,6 +770,11 @@
         <target>SIRI SHORTCUTS</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <target>Add to Shortcuts</target>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Find in Page</target>
@@ -784,6 +789,11 @@
         <source>Page Actions</source>
         <target>Page Actions</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <target>Remove from Shortcuts</target>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -814,6 +824,11 @@
         <source>Share Page With...</source>
         <target>Share Page With...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <target>Remove from Shortcuts</target>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -999,6 +1014,16 @@
         <source>Analytic trackers</source>
         <target>Analytic trackers</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <target>Connection is not secure</target>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <target>Connection is secure</target>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/eo/focus-ios.xliff
+++ b/eo/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>ŜPARVOJOJ DE SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Serĉi en paĝo</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>Retpaĝaj agoj</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>Kundividi paĝon kun...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>Analizaj spuriloj</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/es-AR/focus-ios.xliff
+++ b/es-AR/focus-ios.xliff
@@ -761,6 +761,10 @@
         <target>SIRI SHORTCUTS</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Buscar en la página</target>
@@ -775,6 +779,10 @@
         <source>Page Actions</source>
         <target>Acciones de la página</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -805,6 +813,10 @@
         <source>Share Page With...</source>
         <target>Compartir la página con…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -990,6 +1002,14 @@
         <source>Analytic trackers</source>
         <target>Rastreadores analíticos</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/es-CL/focus-ios.xliff
+++ b/es-CL/focus-ios.xliff
@@ -1,36 +1,35 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Blockzilla/en.lproj/InfoPlist.strings" source-language="en" target-language="es-CL" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="NSCameraUsageDescription" xml:space="preserve">
+      <trans-unit id="NSCameraUsageDescription">
         <source>This lets you take and upload photos.</source>
         <target>Esto te permite tomar y subir fotos.</target>
         <note>Privacy - Camera Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSFaceIDUsageDescription" xml:space="preserve">
+      <trans-unit id="NSFaceIDUsageDescription">
         <source>This lets you unlock the app.</source>
         <target>Esto te permite desbloquear la app.</target>
         <note>Privacy - Face ID Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSLocationWhenInUseUsageDescription" xml:space="preserve">
+      <trans-unit id="NSLocationWhenInUseUsageDescription">
         <source>Websites you visit may request your location.</source>
         <target>Las páginas que visites podrían solicitarte tu ubicación.</target>
         <note>Privacy - Location When In Use Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSMicrophoneUsageDescription" xml:space="preserve">
+      <trans-unit id="NSMicrophoneUsageDescription">
         <source>This lets you take and upload videos.</source>
         <target>Esto te permite tomar y subir videos.</target>
         <note>Privacy - Microphone Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSPhotoLibraryAddUsageDescription" xml:space="preserve">
+      <trans-unit id="NSPhotoLibraryAddUsageDescription">
         <source>This lets you save and upload photos.</source>
         <target>Esto te permite guardar y subir fotos.</target>
         <note>Privacy - Photo Library Additions Usage Description</note>
       </trans-unit>
-      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen" xml:space="preserve">
+      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen">
         <source>Erase and Open</source>
         <target>Borrar y abrir</target>
         <note>This is the menu item that appears when you long press the Focus icon on the phone home screen.</note>
@@ -42,7 +41,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intents.Erase.Title" xml:space="preserve">
+      <trans-unit id="Intents.Erase.Title">
         <source>Erase</source>
         <target>Borrar</target>
         <note>Title of the Erase intent.</note>
@@ -54,42 +53,42 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intro.Slides.History.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Description">
         <source>Clear your entire browsing session history, passwords, cookies anytime with a single tap.</source>
         <target>Limpia tu sesión de navegación completa: historial, contraseñas y cookies, en cual quier momento y con un solo toque.</target>
         <note>Description for the 'History' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.History.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Title">
         <source>Your history is history</source>
         <target>Tu historial es cosa del pasado</target>
         <note>Title for the third  panel 'History' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Next.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Next.Button">
         <source>Next</source>
         <target>Siguiente</target>
         <note>Button to go to the next card in Focus onboarding.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Description">
         <source>Searching for something different? Choose a different search engine.</source>
         <target>¿Buscas algo diferente? Elije un motor de búsqueda diferente.</target>
         <note>Description for the 'Favorite Search Engine' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Title">
         <source>Your search, your way</source>
         <target>Tu búsqueda, a tu manera</target>
         <note>Title for the second  panel 'Search' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Skip.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Skip.Button">
         <source>Skip</source>
         <target>Saltar</target>
         <note>Button to skip onboarding in Focus</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Description">
         <source>Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times.</source>
         <target>Lleva la navegación privada al siguiente nivel. Bloquea la publicidad y otros contenidos que pueden rastrearte entre los sitios y aumentar los tiempos de carga de las páginas.</target>
         <note>Description for the 'Welcome' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Title">
         <source>Power up your privacy</source>
         <target>Potencia tu privacidad</target>
         <note>Title for the first panel 'Welcome' in the First Run tour.</note>
@@ -101,972 +100,992 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="About.learnMoreButton" xml:space="preserve">
+      <trans-unit id="About.learnMoreButton">
         <source>Learn more</source>
         <target>Aprender más</target>
         <note>Button on About screen</note>
       </trans-unit>
-      <trans-unit id="About.missionLabel" xml:space="preserve">
+      <trans-unit id="About.missionLabel">
         <source>%@ is produced by Mozilla. Our mission is to foster a healthy, open Internet.</source>
         <target>%@ es producido por Mozilla. Nuestra misión es promover un Internet sano y abierto.</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet1" xml:space="preserve">
+      <trans-unit id="About.privateBullet1">
         <source>Search and browse right in the app</source>
         <target>Busca y navega directo desde la app</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet2" xml:space="preserve">
+      <trans-unit id="About.privateBullet2">
         <source>Block trackers (or update settings to allow trackers)</source>
         <target>Bloquea rastreadores (o actualiza los ajustes para permitirlos)</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet3" xml:space="preserve">
+      <trans-unit id="About.privateBullet3">
         <source>Erase to delete cookies as well as search and browsing history</source>
         <target>Limpia para eliminar cookies junto al historial de búsqueda y navegación</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBulletHeader" xml:space="preserve">
+      <trans-unit id="About.privateBulletHeader">
         <source>Use it as a private browser:</source>
         <target>Úsalo como un navegador privado:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowHelp" xml:space="preserve">
+      <trans-unit id="About.rowHelp">
         <source>Help</source>
         <target>Ayuda</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowPrivacy" xml:space="preserve">
+      <trans-unit id="About.rowPrivacy">
         <source>Privacy Notice</source>
         <target>Aviso de privacidad</target>
         <note>Link to Privacy Notice in the About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowRights" xml:space="preserve">
+      <trans-unit id="About.rowRights">
         <source>Your Rights</source>
         <target>Tus derechos</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet1" xml:space="preserve">
+      <trans-unit id="About.safariBullet1">
         <source>Block trackers for improved privacy</source>
         <target>Bloquea rastreadores para una privacidad mejorada</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet2" xml:space="preserve">
+      <trans-unit id="About.safariBullet2">
         <source>Block web fonts to reduce page size</source>
         <target>Bloquea fuentes Web para reducir el peso de las páginas</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBulletHeader" xml:space="preserve">
+      <trans-unit id="About.safariBulletHeader">
         <source>Use it as a Safari extension:</source>
         <target>Úsalo como una extensión de Safari:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.title" xml:space="preserve">
+      <trans-unit id="About.title">
         <source>About %@</source>
         <target>Acerca de %@</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, takes the user to a page with information about the product. Also displayed as a header for the About page.</note>
       </trans-unit>
-      <trans-unit id="About.topLabel" xml:space="preserve">
+      <trans-unit id="About.topLabel">
         <source>%@ puts you in control.</source>
         <target>%@ te pone al control.</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Dismiss" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Dismiss">
         <source>Ok</source>
         <target>Ok</target>
         <note>Button to dismiss the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Message" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Message">
         <source>An error occured while adding the pass to Wallet. Please try again later.</source>
         <target>Ocurrió un error al añadir el pase a Wallet. Por favor, vuelve a intentarlo más tarde.</target>
         <note>Message of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Title" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Title">
         <source>Failed to Add Pass</source>
         <target>Falló el añadir el pase</target>
         <note>Title of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="Authentication.reason" xml:space="preserve">
+      <trans-unit id="Authentication.reason">
         <source>Authenticate to return to %@</source>
         <target>Autenticar para regresar a %@</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID, Face ID, or passcode to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrl">
         <source>Add Custom URL</source>
         <target>Añadir URL personalizada</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlError" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlError">
         <source>Double-check the URL you entered.</source>
         <target>Verifica la URL que ingresaste.</target>
         <note>Label for error state when entering an invalid URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlExample" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlExample">
         <source>Example: example.com</source>
         <target>Ejemplo: example.com</target>
         <note>A label displaying an example URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlLabel">
         <source>URL to add</source>
         <target>URL a añadir</target>
         <note>Label for the input to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlPlaceholder" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlPlaceholder">
         <source>Paste or enter URL</source>
         <target>Pega o ingresa una URL</target>
         <note>Placeholder for the input field to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlWithPlus" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlWithPlus">
         <source>+ Add Custom URL</source>
         <target>+ Añadir URL personalizada</target>
         <note>Label for button to add a custom URL with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.customDescriptoin">
         <source>Add and manage custom autocomplete URLs.</source>
         <target>Añadir y gestionar autocompletado de URL personalizadas.</target>
         <note>Description for adding and managing custom autocomplete URLs</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.customLabel">
         <source>Custom URLs</source>
         <target>URLs personalizadas</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.customTitle">
         <source>CUSTOM URL LIST</source>
         <target>LISTA DE URL PERSONALIZADA</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customUrlAdded" xml:space="preserve">
+      <trans-unit id="Autocomplete.customUrlAdded">
         <source>New Custom URL added.</source>
         <target>Nueva URL personalizada añadida.</target>
         <note>Label for toast alerting a custom URL has been added</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultDescriptoin">
         <source>Enable to have %@ autocomplete over 450 popular URLs in the address bar.</source>
         <target>Actívalo para que %@ autocomplete más de 450 URLs populares en la barra de direcciones.</target>
         <note>Description for enabling or disabling the default list. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultLabel">
         <source>Autocomplete</source>
         <target>Autocompletar</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultTitle">
         <source>DEFAULT URL LIST</source>
         <target>LISTA DE URL PREDETERMINADA</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.disabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.disabled">
         <source>Disabled</source>
         <target>Desactivado</target>
         <note>label describing URL Autocomplete as disabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.duplicateUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.duplicateUrl">
         <source>URL already exists</source>
         <target>La URL ya existe</target>
         <note>Label for toast alerting that the custom URL being added is a duplicate</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.emptyState" xml:space="preserve">
+      <trans-unit id="Autocomplete.emptyState">
         <source>No Custom URLs to display</source>
         <target>No hay URLs personalizadas para mostrar</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.enabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.enabled">
         <source>Enabled</source>
         <target>Activado</target>
         <note>label describing URL Autocomplete as enabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.manageSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.manageSites">
         <source>Manage Sites</source>
         <target>Gestionar sitios</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySites" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySites">
         <source>My Sites</source>
         <target>Mis sitios</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySitesDesc" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySitesDesc">
         <source>Enable to have %@ autocomplete your favorite URLs.</source>
         <target>Activar para que %@ autocomplete tus URLs favoritas.</target>
         <note>Description for adding and managing custom autocomplete URLs. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.topSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.topSites">
         <source>Top Sites</source>
         <target>Sitios frecuentes</target>
         <note>Label for enabling or disabling top sites</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.newSession" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.newSession">
         <source>New Session</source>
         <target>Nueva sesión</target>
         <note>Create a new session after failing a biometric check</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.reason" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.reason">
         <source>Unlock %@ when re-opening in order to prevent unauthorized access.</source>
         <target>Desbloquea %@ al reabrirlo para evitar accesos no autorizados.</target>
         <note>%@ is app name. Explanation for why the app needs access to biometric information. Prompt is only shown once when the user first tries to enable Face ID to open the app.</note>
       </trans-unit>
-      <trans-unit id="Browser.backLabel" xml:space="preserve">
+      <trans-unit id="Browser.backLabel">
         <source>Back</source>
         <target>Atrás</target>
         <note>Accessibility label for the back button</note>
       </trans-unit>
-      <trans-unit id="Browser.copyAddressLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyAddressLabel">
         <source>Copy Address</source>
         <target>Copiar dirección</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.copyMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyMenuLabel">
         <source>Copy</source>
         <target>Copiar</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.customURLMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.customURLMenuLabel">
         <source>Add Custom URL</source>
         <target>Añadir URL personalizada</target>
         <note>Custom URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.forwardLabel" xml:space="preserve">
+      <trans-unit id="Browser.forwardLabel">
         <source>Forward</source>
         <target>Adelante</target>
         <note>Accessibility label for the forward button</note>
       </trans-unit>
-      <trans-unit id="Browser.reloadLabel" xml:space="preserve">
+      <trans-unit id="Browser.reloadLabel">
         <source>Reload</source>
         <target>Recargar</target>
         <note>Accessibility label for the reload button</note>
       </trans-unit>
-      <trans-unit id="Browser.settingsLabel" xml:space="preserve">
+      <trans-unit id="Browser.settingsLabel">
         <source>Settings</source>
         <target>Ajustes</target>
         <note>Accessibility label for the settings button</note>
       </trans-unit>
-      <trans-unit id="Browser.shareLabel" xml:space="preserve">
+      <trans-unit id="Browser.shareLabel">
         <source>Share</source>
         <target>Compartir</target>
         <note>Accessibility label for the share button</note>
       </trans-unit>
-      <trans-unit id="Browser.stopLabel" xml:space="preserve">
+      <trans-unit id="Browser.stopLabel">
         <source>Stop</source>
         <target>Detener</target>
         <note>Accessibility label for the stop button</note>
       </trans-unit>
-      <trans-unit id="Cancel" xml:space="preserve">
+      <trans-unit id="Cancel">
         <source>Cancel</source>
         <target>Cancelar</target>
         <note>Label on button to cancel edits</note>
       </trans-unit>
-      <trans-unit id="Done" xml:space="preserve">
+      <trans-unit id="Done">
         <source>Done</source>
         <target>Hecho</target>
         <note>Label on button to complete edits</note>
       </trans-unit>
-      <trans-unit id="Edit" xml:space="preserve">
+      <trans-unit id="Edit">
         <source>Edit</source>
         <target>Editar</target>
         <note>Label on button to allow edits</note>
       </trans-unit>
-      <trans-unit id="Error.tryAgainButton" xml:space="preserve">
+      <trans-unit id="Error.tryAgainButton">
         <source>Try again</source>
         <target>Volver a intentarlo</target>
         <note>Button label to reload the error page</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.cancelTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.cancelTitle">
         <source>Cancel</source>
         <target>Cancelar</target>
         <note>Button label used for cancelling to open another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.messageTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.messageTitle">
         <source>%@ wants to open another App</source>
         <target>%@ quiere abrir otra aplicación</target>
         <note>Dialog title used for opening an external app from Focus. The placeholder string is the app name of either Focus or Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.openTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.openTitle">
         <source>Open</source>
         <target>Abrir</target>
         <note>Button label for opening another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.callButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.callButton">
         <source>Call</source>
         <target>Llamar</target>
         <note>Button label in tel: dialog to call a phone number. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.cancelButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.cancelButton">
         <source>Cancel</source>
         <target>Cancelar</target>
         <note>Button label in external link dialog to cancel the dialog. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.emailButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.emailButton">
         <source>Email</source>
         <target>Correo</target>
         <note>Button label in mailto: dialog to send an email. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.messageTitleWithPlaceholder" xml:space="preserve">
+      <trans-unit id="ExternalLink.messageTitleWithPlaceholder">
         <source>You are now leaving %@.</source>
         <target>Estás saliendo de %@.</target>
         <note>Dialog title used for Maps/App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreButton">
         <source>Open App Store</source>
         <target>Abrir App Store</target>
         <note>Button label in App Store URL dialog to open the App Store. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreTitle" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreTitle">
         <source>%@ wants to open the App Store.</source>
         <target>%@ quiere abrir la App Store.</target>
         <note>Dialog title used to open App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openMapsButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openMapsButton">
         <source>Open Maps</source>
         <target>Abrir Maps</target>
         <note>Button label in Maps URL dialog to open Maps. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="FindInPage.Done" xml:space="preserve">
+      <trans-unit id="FindInPage.Done">
         <source>Find in page done</source>
         <target>Buscar en la página finalizado</target>
         <note>Accessibility label for done button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.NextResult" xml:space="preserve">
+      <trans-unit id="FindInPage.NextResult">
         <source>Find next in page</source>
         <target>Buscar siguiente en la página</target>
         <note>Accessibility label for next result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.PreviousResult" xml:space="preserve">
+      <trans-unit id="FindInPage.PreviousResult">
         <source>Find previous in page</source>
         <target>Buscar anterior en la página</target>
         <note>Accessibility label for previous result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FirstRun.lastSlide.buttonLabel" xml:space="preserve">
+      <trans-unit id="FirstRun.lastSlide.buttonLabel">
         <source>OK, Got It!</source>
         <target>Ok, me quedó clarito</target>
         <note>Label on button to dismiss first run UI</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelDescription" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelDescription">
         <source>Automatically block online trackers while you browse. Then tap to erase visited pages, searches, cookies and passwords from your device.</source>
         <target>Bloquea automáticamente rastreadores en línea mientras navegas. Luego toca para eliminar las páginas visitadas, búsquedas, cookies y contraseñas de tu dispositivo.</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelTagline" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelTagline">
         <source>Browse like no one’s watching.</source>
         <target>Navega como si nadie te estuviese mirando.</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="Focus.handoffSyncing" xml:space="preserve">
+      <trans-unit id="Focus.handoffSyncing">
         <source>Apple Handoff is syncing</source>
         <target>Apple Handoff está sincronizandose</target>
         <note>Title for the loading screen when the handoff of clipboard delays Focus launch. “Handoff” should not be localized, see https://support.apple.com/HT204681</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel1" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel1">
         <source>Automatic private browsing.</source>
         <target>Navegación privada automática.</target>
         <note>First label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel2" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel2">
         <source>Browse. Erase. Repeat.</source>
         <target>Navega. Limpia. Repite.</target>
         <note>Second label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Menu.Close" xml:space="preserve">
+      <trans-unit id="Menu.Close">
         <source>Close</source>
         <target>Cerrar</target>
         <note>Button label used to close a menu that displays as a popup.</note>
       </trans-unit>
-      <trans-unit id="Open.Cancel" xml:space="preserve">
+      <trans-unit id="Open.Cancel">
         <source>Cancel</source>
         <target>Cancelar</target>
         <note>Label in share alert to cancel the alert</note>
       </trans-unit>
-      <trans-unit id="Open.Firefox" xml:space="preserve">
+      <trans-unit id="Open.Firefox">
         <source>Firefox (Private Browsing)</source>
         <target>Firefox (Navegación privada)</target>
         <note>Label in share alert to open the URL in Firefox</note>
       </trans-unit>
-      <trans-unit id="Open.More" xml:space="preserve">
+      <trans-unit id="Open.More">
         <source>More</source>
         <target>Más</target>
         <note>Label in share alert to open the full system share menu</note>
       </trans-unit>
-      <trans-unit id="Open.Safari" xml:space="preserve">
+      <trans-unit id="Open.Safari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Label in share alert to open the URL in Safari</note>
       </trans-unit>
-      <trans-unit id="Request Desktop Site" xml:space="preserve">
+      <trans-unit id="Request Desktop Site">
         <source>Request Desktop Site</source>
         <target>Solicitar sitio de escritorio</target>
         <note>Label for button that requests the desktop version of the currently loaded website.</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsContentBlockers" xml:space="preserve">
+      <trans-unit id="Safari.instructionsContentBlockers">
         <source>Tap Safari, then select Content Blockers</source>
         <target>Toca Safari, luego selecciona Bloqueadores de contenido</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsEnable" xml:space="preserve">
+      <trans-unit id="Safari.instructionsEnable">
         <source>Enable %@</source>
         <target>Activar %@</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsNotEnabled" xml:space="preserve">
+      <trans-unit id="Safari.instructionsNotEnabled">
         <source>%@ is not enabled.</source>
         <target>%@ no está activado.</target>
         <note>Error label when the blocker is not enabled, shown in the intro and main app when disabled</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsOpen" xml:space="preserve">
+      <trans-unit id="Safari.instructionsOpen">
         <source>Open Settings App</source>
         <target>Abre la app de Ajustes</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Save" xml:space="preserve">
+      <trans-unit id="Save">
         <source>Save</source>
         <target>Guardar</target>
         <note>Save button label</note>
       </trans-unit>
-      <trans-unit id="SearchEngine.addEngineError" xml:space="preserve">
+      <trans-unit id="SearchEngine.addEngineError">
         <source>That didn't work. Try replacing the search term with this: %s.</source>
         <target>Eso no funcionó. Intenta reemplazar el término de búsqueda con esto: %s.</target>
         <note>Label for error state when entering an invalid search engine URL. %s is a search term in a URL.</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptDisable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptDisable">
         <source>No</source>
         <target>No</target>
         <note>Label for disable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptEnable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptEnable">
         <source>Yes</source>
         <target>Sí</target>
         <note>Label for enable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptMessage" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptMessage">
         <source>To get suggestions, %@ needs to send what you type in the address bar to the search engine.</source>
         <target>Para recibir sugerencias, %@ necesita enviar lo que escribas en la barra de direcciones al motor de búsqueda.</target>
         <note>%@ is the name of the app (Focus / Klar). Label for search suggestions prompt message</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptTitle" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptTitle">
         <source>Show Search Suggestions?</source>
         <target>¿Mostrar sugerencias de búsqueda?</target>
         <note>Title for search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButton" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButton">
         <source>Add Another Search Engine</source>
         <target>Añadir otro motor de búsqueda</target>
         <note>Text for button to add another search engine in settings</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus">
         <source>+ Add Another Search Engine</source>
         <target>+ Añadir otro motor de búsqueda</target>
         <note>Text for button to add another search engine in settings with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineTitle" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineTitle">
         <source>Add Search Engine</source>
         <target>Añadir motor de búsqueda</target>
         <note>Title on add search engine settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.InstalledSearchEngines" xml:space="preserve">
+      <trans-unit id="Settings.Search.InstalledSearchEngines">
         <source>INSTALLED SEARCH ENGINES</source>
         <target>MOTORES DE BÚSQUEDA INSTALADOS</target>
         <note>Header for rows of installed search engines</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NameToDisplay" xml:space="preserve">
+      <trans-unit id="Settings.Search.NameToDisplay">
         <source>Name to display</source>
         <target>Nombre para mostrar</target>
         <note>Label for input field for the name of the search engine to be added</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NewSearchEngineAdded" xml:space="preserve">
+      <trans-unit id="Settings.Search.NewSearchEngineAdded">
         <source>New Search Engine Added.</source>
         <target>Nuevo motor de búsqueda añadido.</target>
         <note>Toast displayed after adding a search engine</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.RestoreEngine" xml:space="preserve">
+      <trans-unit id="Settings.Search.RestoreEngine">
         <source>Restore Default Search Engines</source>
         <target>Restaurar motores de búsqueda predeterminados</target>
         <note>Label for button to bring deleted default engines back</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchEngineName" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchEngineName">
         <source>Search engine name</source>
         <target>Nombre del motor de búsqueda</target>
         <note>Placeholder text for input of new search engine name</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplate" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplate">
         <source>Search string to use</source>
         <target>Cadena de búsqueda a usar</target>
         <note>Label for input of search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplatePlaceholder" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplatePlaceholder">
         <source>Paste or enter search string. If necessary, replace search term with: %s.</source>
         <target>Pega o ingresa la cadena de búsqueda. De ser necesario, reemplaza el término de búsqueda con: %s.</target>
         <note>Placeholder text for input of new search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.autocompleteSection" xml:space="preserve">
+      <trans-unit id="Settings.autocompleteSection">
         <source>URL Autocomplete</source>
         <target>Autocompletar URL</target>
         <note>Title for the URL Autocomplete row</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherMessage" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherMessage">
         <source>Blocking other content trackers may break some videos and web pages.</source>
         <target>Bloquear otros rastreadores de contenido puede interferir con algunos videos y páginas Web.</target>
         <note>Alert message shown when toggling the Content blocker</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherNo2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherNo2">
         <source>Cancel</source>
         <target>Cancelar</target>
         <note>Button label for declining Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherYes2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherYes2">
         <source>Block Content Trackers</source>
         <target>Bloquear rastreadores de contenido</target>
         <note>Button label for accepting Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSearchSuggestion" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSearchSuggestion">
         <source>%@ will send what you type in the address bar to your search engine.</source>
         <target>%@ enviará lo que escribas en la barra de direcciones a tu motor de búsqueda.</target>
         <note>Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSendUsageData">
         <source>Mozilla strives to collect only what we need to provide and improve %@ for everyone.</source>
         <target>Mozilla se esfuerza por recolectar solo lo que necesitama para proporcionar y mejorar %@ para todos.</target>
         <note>Description associated to the Send Usage Data toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.learnMore" xml:space="preserve">
+      <trans-unit id="Settings.learnMore">
         <source>Learn more.</source>
         <target>Aprender más.</target>
         <note>Subtitle for Send Anonymous Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.rate" xml:space="preserve">
+      <trans-unit id="Settings.rate">
         <source>Rate %@</source>
         <target>Evaluar %@</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, allows the user to leave a review for the app on the app store.</note>
       </trans-unit>
-      <trans-unit id="Settings.safariTitle" xml:space="preserve">
+      <trans-unit id="Settings.safariTitle">
         <source>SAFARI INTEGRATION</source>
         <target>INTEGRACIÓN CON SAFARI</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.screenTitle" xml:space="preserve">
+      <trans-unit id="Settings.screenTitle">
         <source>Settings</source>
         <target>Ajustes</target>
         <note>Title for settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchLabel" xml:space="preserve">
+      <trans-unit id="Settings.searchLabel">
         <source>Search Engine</source>
         <target>Motor de búsqueda</target>
         <note>Label for the search engine in the search screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchSuggestions" xml:space="preserve">
+      <trans-unit id="Settings.searchSuggestions">
         <source>Get Search Suggestions</source>
         <target>Recibir sugerencias de búsqueda</target>
         <note>Label for the Search Suggestions toggle row</note>
       </trans-unit>
-      <trans-unit id="Settings.searchTitle2" xml:space="preserve">
+      <trans-unit id="Settings.searchTitle2">
         <source>SEARCH</source>
         <target>BÚSQUEDA</target>
         <note>Title for the search selection screen</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionIntegration" xml:space="preserve">
+      <trans-unit id="Settings.sectionIntegration">
         <source>INTEGRATION</source>
         <target>INTEGRACIÓN</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionMozilla" xml:space="preserve">
+      <trans-unit id="Settings.sectionMozilla">
         <source>MOZILLA</source>
         <target>MOZILLA</target>
         <note>Section label for Mozilla toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPerformance" xml:space="preserve">
+      <trans-unit id="Settings.sectionPerformance">
         <source>PERFORMANCE</source>
         <target>RENDIMIENTO</target>
         <note>Section label for performance toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPrivacy" xml:space="preserve">
+      <trans-unit id="Settings.sectionPrivacy">
         <source>PRIVACY</source>
         <target>PRIVACIDAD</target>
         <note>Section label for privacy toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionSecurity" xml:space="preserve">
+      <trans-unit id="Settings.sectionSecurity">
         <source>SECURITY</source>
         <target>SEGURIDAD</target>
         <note>Header label for security toggles displayed in the settings menu</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAds2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAds2">
         <source>Advertising</source>
         <target>Publicidad</target>
         <note>Label for the checkbox to toggle Advertising trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAnalytics2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAnalytics2">
         <source>Analytics</source>
         <target>Analítica</target>
         <note>Label for the checkbox to toggle Analytics trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockFonts" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockFonts">
         <source>Block web fonts</source>
         <target>Bloquear fuentes Web</target>
         <note>Label for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockOther2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockOther2">
         <source>Content</source>
         <target>Contenido</target>
         <note>Label for the checkbox to toggle Other trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockSocial2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockSocial2">
         <source>Social</source>
         <target>Social</target>
         <note>Label for the checkbox to toggle Social trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceID" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceID">
         <source>Use Face ID to unlock app</source>
         <target>Usar Face ID para desbloquear la app</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceIDDescription">
         <source>Face ID can unlock %@ if a URL is already open in the app</source>
         <target>Face ID puede desbloquear %@ si una URL ya está abierta en la app</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Face ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleHomeScreenTips" xml:space="preserve">
+      <trans-unit id="Settings.toggleHomeScreenTips">
         <source>Show home screen tips</source>
         <target>Mostrar consejos en la pantalla de inicio</target>
         <note>Show home screen tips toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleOtherSubtitle" xml:space="preserve">
+      <trans-unit id="Settings.toggleOtherSubtitle">
         <source>May break some videos and Web pages</source>
         <target>Puede interferir con algunos videos y páginas Web</target>
         <note>Label subtitle for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSafari" xml:space="preserve">
+      <trans-unit id="Settings.toggleSafari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Safari toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.toggleSendUsageData">
         <source>Send usage data</source>
         <target>Enviar datos de uso</target>
         <note>Label for Send Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchID" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchID">
         <source>Use Touch ID to unlock app</source>
         <target>Usar Touch ID para desbloquear la app</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchIDDescription">
         <source>Touch ID can unlock %@ if a URL is already open in the app</source>
         <target>Touch ID puede desbloquear %@ si una URL ya está abierta en la app</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Touch ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOff" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOff">
         <source>Off</source>
         <target>No</target>
         <note>Status off for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOn" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOn">
         <source>On</source>
         <target>Sí</target>
         <note>Status on for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.whatsNewTitle" xml:space="preserve">
+      <trans-unit id="Settings.whatsNewTitle">
         <source>What’s New</source>
         <target>Qué hay de nuevo</target>
         <note>Title for What's new screen</note>
       </trans-unit>
-      <trans-unit id="Settinsg.siriShortcutsTitle" xml:space="preserve">
+      <trans-unit id="Settinsg.siriShortcutsTitle">
         <source>SIRI SHORTCUTS</source>
         <target>ATAJOS DE SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.FindInPage" xml:space="preserve">
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Buscar en la página</target>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.GetFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.GetFirefox">
         <source>Get the Firefox App</source>
         <target>Obtén la aplicación de Firefox</target>
         <note>Text for the share menu option when a user wants to open a page in Firefox but doesn’t have it installed. This string will not wrap in the interface. Instead, it will truncate. To prevent this, please keep the localized string to 18 or fewer characters. If your string runs longer than 18 characters, you can use 'Get Firefox' as the basis for your string. However, if at all possible, we’d like to signal to the user that they will be going to the App Store and installing the application from there. That is why we are using Get and App in the en-US string.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.PageActions" xml:space="preserve">
+      <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <target>Acciones de la página</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestDesktop" xml:space="preserve">
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
         <target>Solicitar sitio de escritorio</target>
         <note>Text for the share menu option when a user wants to reload the site as a desktop</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestMobile" xml:space="preserve">
+      <trans-unit id="ShareMenu.RequestMobile">
         <source>Request Mobile Site</source>
         <target>Solicitar sitio para móviles</target>
         <note>Text for the share menu option when a user wants to reload the site as a mobile device</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenChrome" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenChrome">
         <source>Open in Chrome</source>
         <target>Abrir en Chrome</target>
         <note>Text for the share menu option when a user wants to open the current website in the Chrome app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenFirefox">
         <source>Open in Firefox</source>
         <target>Abrir en Firefox</target>
         <note>Text for the share menu option when a user wants to open the current website in the Firefox app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenSafari" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenSafari">
         <source>Open in Safari</source>
         <target>Abrir en Safari</target>
         <note>Text for the share menu option when a user wants to open the current website in the Safari app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.SharePage" xml:space="preserve">
+      <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <target>Compartir la página con…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
       </trans-unit>
-      <trans-unit id="Siri.add" xml:space="preserve">
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
+      </trans-unit>
+      <trans-unit id="Siri.add">
         <source>Add</source>
         <target>Añadir</target>
         <note>Button to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.addTo" xml:space="preserve">
+      <trans-unit id="Siri.addTo">
         <source>Add to Siri</source>
         <target>Añadir a Siri</target>
         <note>Button to add a specified shortcut option to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.editOpenUrl" xml:space="preserve">
+      <trans-unit id="Siri.editOpenUrl">
         <source>Re-Record or Delete Shortcut</source>
         <target>Volver a grabar o eliminar el acceso directo</target>
         <note>Label for button to edit the Siri phrase or delete the Siri functionality.</note>
       </trans-unit>
-      <trans-unit id="Siri.erase" xml:space="preserve">
+      <trans-unit id="Siri.erase">
         <source>Erase</source>
         <target>Borrar</target>
         <note>Title of option in settings to set up Siri to erase</note>
       </trans-unit>
-      <trans-unit id="Siri.eraseAndOpen" xml:space="preserve">
+      <trans-unit id="Siri.eraseAndOpen">
         <source>Erase &amp; Open</source>
         <target>Borrar y abrir</target>
         <note>Title of option in settings to set up Siri to erase and then open the app.</note>
       </trans-unit>
-      <trans-unit id="Siri.favoriteUrl" xml:space="preserve">
+      <trans-unit id="Siri.favoriteUrl">
         <source>Open Favorite Site</source>
         <target>Abrir sitio favorito</target>
         <note>Title for screen to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.openURL" xml:space="preserve">
+      <trans-unit id="Siri.openURL">
         <source>Open Favorite Site</source>
         <target>Abrir sitio favorito</target>
         <note>Title of option in settings to set up Siri to open a specified URL in Focus/Klar.</note>
       </trans-unit>
-      <trans-unit id="Siri.urlToOpen" xml:space="preserve">
+      <trans-unit id="Siri.urlToOpen">
         <source>URL to open</source>
         <target>URL a abrir</target>
         <note>Label for input to set a favorite URL to be opened by Siri.</note>
       </trans-unit>
-      <trans-unit id="URL.addToAutocompleteLabel" xml:space="preserve">
+      <trans-unit id="URL.addToAutocompleteLabel">
         <source>Add link to autocomplete</source>
         <target>Añadir el enlace para autocompletar</target>
         <note>Label displayed for button used as a shortcut to add a link to the list of URLs to autocomplete.</note>
       </trans-unit>
-      <trans-unit id="URL.cancelLabel" xml:space="preserve">
+      <trans-unit id="URL.cancelLabel">
         <source>Cancel</source>
         <target>Cancelar</target>
         <note>Label for cancel button shown when entering a URL or search</note>
       </trans-unit>
-      <trans-unit id="URL.contextMenu" xml:space="preserve">
+      <trans-unit id="URL.contextMenu">
         <source>Paste &amp; Go</source>
         <target>Pegar e ir</target>
         <note>Text for the URL context menu when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.eraseButtonLabel" xml:space="preserve">
+      <trans-unit id="URL.eraseButtonLabel">
         <source>ERASE</source>
         <target>LIMPIAR</target>
         <note>Erase button in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.eraseMessageLabel2" xml:space="preserve">
+      <trans-unit id="URL.eraseMessageLabel2">
         <source>Browsing history cleared</source>
         <target>Historial de navegación limpiado</target>
         <note>Message shown after pressing the Erase button</note>
       </trans-unit>
-      <trans-unit id="URL.findOnPageLabel" xml:space="preserve">
+      <trans-unit id="URL.findOnPageLabel">
         <source>Find in page: %@</source>
         <target>Buscar en la página: %@</target>
         <note>Label displayed for find in page button when typing in the URL Bar. %@ is any text the user has typed into the URL bar that they want to find on the current page.</note>
       </trans-unit>
-      <trans-unit id="URL.paste" xml:space="preserve">
+      <trans-unit id="URL.paste">
         <source>Paste</source>
         <target>Pegar</target>
         <note>Text for a menu displayed from the bottom of the screen when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.placeholderText" xml:space="preserve">
+      <trans-unit id="URL.placeholderText">
         <source>Search or enter address</source>
         <target>Buscar o ingresar dirección</target>
         <note>Placeholder text shown in the URL bar before the user navigates to a page</note>
       </trans-unit>
-      <trans-unit id="URL.searchLabel" xml:space="preserve">
+      <trans-unit id="URL.searchLabel">
         <source>Search for %@</source>
         <target>Buscar por %@</target>
         <note>Label displayed for search button when typing in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="URL.trackersBlockedLabel">
         <source>Trackers blocked</source>
         <target>Rastreadores bloqueados</target>
         <note>Text for the URL bar showing the number of trackers blocked on a webpage.</note>
       </trans-unit>
-      <trans-unit id="actionSheet.openIn" xml:space="preserve">
+      <trans-unit id="actionSheet.openIn">
         <source>Open in %@</source>
         <target>Abrir en %@</target>
         <note>Title for action sheet item to open the current page in another application. Placeholder is the name of the application to open the current page.</note>
       </trans-unit>
-      <trans-unit id="browser.copyAddressToast" xml:space="preserve">
+      <trans-unit id="browser.copyAddressToast">
         <source>URL Copied To Clipboard</source>
         <target>URL copiada al portapapeles</target>
         <note>Toast displayed after a URL has been copied to the clipboard</note>
       </trans-unit>
-      <trans-unit id="browserShortcutDescription.selectLocationBar" xml:space="preserve">
+      <trans-unit id="browserShortcutDescription.selectLocationBar">
         <source>Select Location Bar</source>
         <target>Seleccionar barra de ubicación</target>
         <note>Label to display in the Discoverability overlay for keyboard shortcuts</note>
       </trans-unit>
-      <trans-unit id="contextMenu.clipboardLink" xml:space="preserve">
+      <trans-unit id="contextMenu.clipboardLink">
         <source>Link you copied: %@</source>
         <target>Enlace que copiaste: %@</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.copyImageTitle">
         <source>Copy Image</source>
         <target>Copiar imagen</target>
         <note>Text for the context menu when a user wants to copy an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyLink" xml:space="preserve">
+      <trans-unit id="contextMenu.copyLink">
         <source>Copy Link</source>
         <target>Copiar enlace</target>
         <note>Text for the context menu when a user wants to copy a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.linkCopied" xml:space="preserve">
+      <trans-unit id="contextMenu.linkCopied">
         <source>Link you copied: </source>
         <target>Enlace que copiaste:</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.saveImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.saveImageTitle">
         <source>Save Image</source>
         <target>Guardar imagen</target>
         <note>Text for the context menu when a user wants to save an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.shareLinkTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.shareLinkTitle">
         <source>Share Link</source>
         <target>Compartir enlace</target>
         <note>Text for the context menu when a user wants to share a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="externalAppLinkWithAppName.messageTitle" xml:space="preserve">
+      <trans-unit id="externalAppLinkWithAppName.messageTitle">
         <source>%1$@ wants to open %2$@</source>
         <target>%1$@ quiere abrir %2$@</target>
         <note>Dialog title used for opening an external app from Focus. First placeholder string is the app name of either Focus or Klar and the second placeholder string specifies the app it wants to open.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.description" xml:space="preserve">
+      <trans-unit id="photosPermission.description">
         <source>This lets you save images to your Camera Roll</source>
         <target>Esto te permite guardar imágenes en tu carrete</target>
         <note>Description for dialog used for requesting a user to enable access to Photos.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.openSettings" xml:space="preserve">
+      <trans-unit id="photosPermission.openSettings">
         <source>Open Settings</source>
         <target>Abrir Ajustes</target>
         <note>Title for button that takes the user to system settings</note>
       </trans-unit>
-      <trans-unit id="photosPermission.title" xml:space="preserve">
+      <trans-unit id="photosPermission.title">
         <source>“%@” Would Like to Access Your Photos</source>
         <target>“%@” desea acceder a tus fotos</target>
         <note>Dialog title used for requesting a user to enable access to Photos. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="settings.Search.SearchTemplateExample" xml:space="preserve">
+      <trans-unit id="settings.Search.SearchTemplateExample">
         <source>Example: searchengineexample.com/search/?q=%s</source>
         <target>Ejemplo: searchengineexample.com/search/?q=%s</target>
         <note>Text displayed as an example of the template to add a search engine.</note>
       </trans-unit>
-      <trans-unit id="share" xml:space="preserve">
+      <trans-unit id="share">
         <source>Share</source>
         <target>Compartir</target>
         <note>Text for a share button</note>
       </trans-unit>
-      <trans-unit id="shareMenu.copyAddress" xml:space="preserve">
+      <trans-unit id="shareMenu.copyAddress">
         <source>Copy Address</source>
         <target>Copiar dirección</target>
         <note>Text for the share menu when a user wants to copy a URL.</note>
       </trans-unit>
-      <trans-unit id="touchId.reason" xml:space="preserve">
+      <trans-unit id="touchId.reason">
         <source>Use Touch ID to return to %@</source>
         <target>Usar Touch ID para regresar a %@</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.adTrackersLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.adTrackersLabel">
         <source>Ad trackers</source>
         <target>Rastreadores de publicidad</target>
         <note>Label for ad trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.analyticTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.analyticTrackerLabel">
         <source>Analytic trackers</source>
         <target>Rastreadores analíticos</target>
         <note>label for analytic trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.contentTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>
         <target>Rastreadores de contenido</target>
         <note>label for content trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.disabledLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.disabledLabel">
         <source>Tracking Protection off</source>
         <target>Protección de seguimiento desactivada</target>
         <note>text showing the tracking protection is disabled.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.label" xml:space="preserve">
+      <trans-unit id="trackingProtection.label">
         <source>Tracking Protection</source>
         <target>Protección de seguimiento</target>
         <note>Title for the tracking settings page to change what trackers are blocked.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.labelDescription" xml:space="preserve">
+      <trans-unit id="trackingProtection.labelDescription">
         <source>Turning this off may fix some site problems</source>
         <target>Desactivar esto puede solucionar algunos problemas del sitio</target>
         <note>Description/subtitle for the tracking protection label.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.learnMore" xml:space="preserve">
+      <trans-unit id="trackingProtection.learnMore">
         <source>Learn More</source>
         <target>Aprender más</target>
         <note>Text for the button to learn more about Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.moreSettings" xml:space="preserve">
+      <trans-unit id="trackingProtection.moreSettings">
         <source>More Settings</source>
         <target>Más ajustes</target>
         <note>Text for the button that closes the Shield Data and opens the regular Settings screen.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.socialTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.socialTrackerLabel">
         <source>Social trackers</source>
         <target>Rastreadores sociales</target>
         <note>label for social trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOff" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOff">
         <source>Protections are OFF for this session</source>
         <target>Las protecciones están desactivadas para esta sesión</target>
         <note>Text for the status off from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOn" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOn">
         <source>Protections are ON for this session</source>
         <target>Las protecciones están activadas para esta sesión</target>
         <note>Text for the status on from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleDescription1" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleDescription1">
         <source>Disable until you close %@ or tap ERASE.</source>
         <target>Desactivar hasta que cierres %@ o toques LIMPIAR.</target>
         <note>Description for the tracking protection toggle. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleLabel2">
         <source>Enhanced Tracking Protection</source>
         <target>Protección de seguimiento mejorada</target>
         <note>Text for the toggle that enables/disables tracking protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackerDescriptionLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackerDescriptionLabel2">
         <source>Keep your data to yourself. %@ protects you from many of the most common trackers that follow what you do online.</source>
         <target>Mantén tus datos privados. %@ te protege de la mayoría de los rastreadores comunes que siguen lo que haces en línea.</target>
         <note>General description of tracking protection settings, which is displayed underneath the trackers preferences in Settings. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersBlockedLabel">
         <source>Trackers blocked since %@</source>
         <target>%@ rastreadores bloqueados desde la instalación</target>
         <note>Text for tracking protection screen showing the number of trackers blocked since the app install. The placeholder is replaced with the install date of the application.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersHeader" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersHeader">
         <source>Trackers and scripts to block</source>
         <target>Rastreadores y scripts a bloquear</target>
         <note>Text for the header of trackers section from Tracking Protection.</note>
@@ -1078,7 +1097,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="SettingsBundle.Licenses" xml:space="preserve">
+      <trans-unit id="SettingsBundle.Licenses">
         <source>Licenses</source>
         <target>Licencias</target>
         <note>The title of the Licenses setting in the settings that Focus shows in the global iOS Settings app.</note>
@@ -1086,3 +1105,4 @@
     </body>
   </file>
 </xliff>
+

--- a/es-ES/focus-ios.xliff
+++ b/es-ES/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>ACCESOS DIRECTOS SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Buscar en la página</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>Acciones de la página</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>Compartir página con...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>Rastreadores analíticos</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/es-MX/focus-ios.xliff
+++ b/es-MX/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>ACCESOS DIRECTOS DE SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Buscar en la página</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>Acciones de la página</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>Compartir página con...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>Rastreador de analítica</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/eu/focus-ios.xliff
+++ b/eu/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>SIRI LASTERBIDEAK</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Bilatu orrian</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>Orri-ekintzak</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>Partekatu orria honekin...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>Estatistiken jarraipen-elementuak</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/fa/focus-ios.xliff
+++ b/fa/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>SIRI SHORTCUTS</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>پیدا کردن در صفحه</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>اقدامات صفحه</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>همرسانی صفحه با...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>دنبال کنندگان تجزیه تحلیلی کننده</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/fi/focus-ios.xliff
+++ b/fi/focus-ios.xliff
@@ -740,6 +740,10 @@
         <target>SIRI-OIKOTIET</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Etsi sivulta</target>
@@ -754,6 +758,10 @@
         <source>Page Actions</source>
         <target>Sivun toiminnot</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -784,6 +792,10 @@
         <source>Share Page With...</source>
         <target>Jaa sivu...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -964,6 +976,14 @@
         <source>Analytic trackers</source>
         <target>Analytiikkaseuraimet</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/fr/focus-ios.xliff
+++ b/fr/focus-ios.xliff
@@ -761,6 +761,10 @@
         <target>RACCOURCIS SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Rechercher dans la page</target>
@@ -775,6 +779,10 @@
         <source>Page Actions</source>
         <target>Actions pour la page</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -805,6 +813,10 @@
         <source>Share Page With...</source>
         <target>Partager la page avec…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -990,6 +1002,14 @@
         <source>Analytic trackers</source>
         <target>Traqueurs de statistiques</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/ga-IE/focus-ios.xliff
+++ b/ga-IE/focus-ios.xliff
@@ -671,6 +671,10 @@
         <source>SIRI SHORTCUTS</source>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
@@ -683,6 +687,10 @@
       <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -707,6 +715,10 @@
       <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -860,6 +872,14 @@
       <trans-unit id="trackingProtection.analyticTrackerLabel">
         <source>Analytic trackers</source>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/gd/focus-ios.xliff
+++ b/gd/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>ATH-GHOIRIDEAN SHIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Lorg san duilleag</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>Gnìomhan na duilleige</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>Co-roinn an duilleag le...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>Tracaichean anailiseach</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/gu-IN/focus-ios.xliff
+++ b/gu-IN/focus-ios.xliff
@@ -687,6 +687,10 @@
         <source>SIRI SHORTCUTS</source>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
@@ -699,6 +703,10 @@
       <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -724,6 +732,10 @@
         <source>Share Page With...</source>
         <target>આની સાથે પૃષ્ઠ શેર કરો...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -897,6 +909,14 @@
         <source>Analytic trackers</source>
         <target>વિશ્લેષણાત્મક ટ્રેકર્સ</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/he/focus-ios.xliff
+++ b/he/focus-ios.xliff
@@ -1,36 +1,35 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Blockzilla/en.lproj/InfoPlist.strings" source-language="en" target-language="he" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="NSCameraUsageDescription" xml:space="preserve">
+      <trans-unit id="NSCameraUsageDescription">
         <source>This lets you take and upload photos.</source>
         <target>אפשרות זו מאפשרת לצלם ולהעלות תמונות.</target>
         <note>Privacy - Camera Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSFaceIDUsageDescription" xml:space="preserve">
+      <trans-unit id="NSFaceIDUsageDescription">
         <source>This lets you unlock the app.</source>
         <target>אפשרות זו מאפשרת לך לשחרר את הנעילה של היישומון.</target>
         <note>Privacy - Face ID Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSLocationWhenInUseUsageDescription" xml:space="preserve">
+      <trans-unit id="NSLocationWhenInUseUsageDescription">
         <source>Websites you visit may request your location.</source>
         <target>אתרים בשימושך עשויים לבקש ממך את המיקום שלך.</target>
         <note>Privacy - Location When In Use Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSMicrophoneUsageDescription" xml:space="preserve">
+      <trans-unit id="NSMicrophoneUsageDescription">
         <source>This lets you take and upload videos.</source>
         <target>אפשרות זו מאפשרת להסריט ולהעלות וידאו.</target>
         <note>Privacy - Microphone Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSPhotoLibraryAddUsageDescription" xml:space="preserve">
+      <trans-unit id="NSPhotoLibraryAddUsageDescription">
         <source>This lets you save and upload photos.</source>
         <target>תכונה זו מאפשרת לך לשמור ולהעלות תמונות.</target>
         <note>Privacy - Photo Library Additions Usage Description</note>
       </trans-unit>
-      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen" xml:space="preserve">
+      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen">
         <source>Erase and Open</source>
         <target>מחיקה ופתיחה</target>
         <note>This is the menu item that appears when you long press the Focus icon on the phone home screen.</note>
@@ -42,7 +41,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intents.Erase.Title" xml:space="preserve">
+      <trans-unit id="Intents.Erase.Title">
         <source>Erase</source>
         <target>מחיקה</target>
         <note>Title of the Erase intent.</note>
@@ -54,42 +53,42 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intro.Slides.History.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Description">
         <source>Clear your entire browsing session history, passwords, cookies anytime with a single tap.</source>
         <target>ניתן בכל עת לנקות את כל היסטורית הגלישה שלך, הסיסמאות והעוגיות בהקשה אחת.</target>
         <note>Description for the 'History' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.History.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Title">
         <source>Your history is history</source>
         <target>ההיסטוריה שלך שייכת לעבר</target>
         <note>Title for the third  panel 'History' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Next.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Next.Button">
         <source>Next</source>
         <target>הבא</target>
         <note>Button to go to the next card in Focus onboarding.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Description">
         <source>Searching for something different? Choose a different search engine.</source>
         <target>חיפשת משהו אחר? ניתן לבחור במנוע חיפוש אחר.</target>
         <note>Description for the 'Favorite Search Engine' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Title">
         <source>Your search, your way</source>
         <target>החיפוש שלך, בדרך שלך</target>
         <note>Title for the second  panel 'Search' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Skip.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Skip.Button">
         <source>Skip</source>
         <target>דילוג</target>
         <note>Button to skip onboarding in Focus</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Description">
         <source>Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times.</source>
         <target>ניתן לקחת את הגלישה הפרטית לשלב הבא. לחסום פרסומות ותוכן אחר שיכול לעקוב אחריך בין אתרים שונים ולהאט את מהירות טעינת האתרים.</target>
         <note>Description for the 'Welcome' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Title">
         <source>Power up your privacy</source>
         <target>פרטיות מוגברת</target>
         <note>Title for the first panel 'Welcome' in the First Run tour.</note>
@@ -101,187 +100,187 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="About.learnMoreButton" xml:space="preserve">
+      <trans-unit id="About.learnMoreButton">
         <source>Learn more</source>
         <target>מידע נוסף</target>
         <note>Button on About screen</note>
       </trans-unit>
-      <trans-unit id="About.missionLabel" xml:space="preserve">
+      <trans-unit id="About.missionLabel">
         <source>%@ is produced by Mozilla. Our mission is to foster a healthy, open Internet.</source>
         <target>u200f%@ פותח על־ידי Mozilla. המשימה שלנו היא לטפח רשת אינטרנט פתוחה ובריאה.</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet1" xml:space="preserve">
+      <trans-unit id="About.privateBullet1">
         <source>Search and browse right in the app</source>
         <target>חיפוש וגלישה ישירות מהיישום</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet2" xml:space="preserve">
+      <trans-unit id="About.privateBullet2">
         <source>Block trackers (or update settings to allow trackers)</source>
         <target>חסימת רכיבי מעקב (או עדכון הגדרות לצורך אפשור רכיבי מעקב)</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet3" xml:space="preserve">
+      <trans-unit id="About.privateBullet3">
         <source>Erase to delete cookies as well as search and browsing history</source>
         <target>מחיקת עוגיות כמו גם חיפוש והיסטורית גלישה</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBulletHeader" xml:space="preserve">
+      <trans-unit id="About.privateBulletHeader">
         <source>Use it as a private browser:</source>
         <target>שימוש לגלישה פרטית:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowHelp" xml:space="preserve">
+      <trans-unit id="About.rowHelp">
         <source>Help</source>
         <target>עזרה</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowPrivacy" xml:space="preserve">
+      <trans-unit id="About.rowPrivacy">
         <source>Privacy Notice</source>
         <target>הצהרת פרטיות</target>
         <note>Link to Privacy Notice in the About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowRights" xml:space="preserve">
+      <trans-unit id="About.rowRights">
         <source>Your Rights</source>
         <target>הזכויות שלך</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet1" xml:space="preserve">
+      <trans-unit id="About.safariBullet1">
         <source>Block trackers for improved privacy</source>
         <target>חסימת רכיבי מעקב, לפרטיות מוגברת</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet2" xml:space="preserve">
+      <trans-unit id="About.safariBullet2">
         <source>Block web fonts to reduce page size</source>
         <target>חסימת גופני רשת כדי לצמצם את משקל הדף</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBulletHeader" xml:space="preserve">
+      <trans-unit id="About.safariBulletHeader">
         <source>Use it as a Safari extension:</source>
         <target>שימוש כהרחבה עבור Safari:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.title" xml:space="preserve">
+      <trans-unit id="About.title">
         <source>About %@</source>
         <target>על אודות %@</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, takes the user to a page with information about the product. Also displayed as a header for the About page.</note>
       </trans-unit>
-      <trans-unit id="About.topLabel" xml:space="preserve">
+      <trans-unit id="About.topLabel">
         <source>%@ puts you in control.</source>
         <target>u200f%@ שם אותך בשליטה.</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Dismiss" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Dismiss">
         <source>Ok</source>
         <target>אישור</target>
         <note>Button to dismiss the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Message" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Message">
         <source>An error occured while adding the pass to Wallet. Please try again later.</source>
         <target>אירעה תקלה בעת הוספת הססמה לארנק. נא לנסות שוב מאוחר יותר.</target>
         <note>Message of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Title" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Title">
         <source>Failed to Add Pass</source>
         <target>הוספת הססמה נכשלה</target>
         <note>Title of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="Authentication.reason" xml:space="preserve">
+      <trans-unit id="Authentication.reason">
         <source>Authenticate to return to %@</source>
         <target>עליך לעבור אימות כדי לחזור אל %@</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID, Face ID, or passcode to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrl">
         <source>Add Custom URL</source>
         <target>הוספת כתובת מותאמת אישית</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlError" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlError">
         <source>Double-check the URL you entered.</source>
         <target>נא לבדוק שוב את הכתובת שהקלדת.</target>
         <note>Label for error state when entering an invalid URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlExample" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlExample">
         <source>Example: example.com</source>
         <target>דוגמה: example.com</target>
         <note>A label displaying an example URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlLabel">
         <source>URL to add</source>
         <target>כתובת להוספה</target>
         <note>Label for the input to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlPlaceholder" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlPlaceholder">
         <source>Paste or enter URL</source>
         <target>נא להדביק או להקליד כתובת</target>
         <note>Placeholder for the input field to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlWithPlus" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlWithPlus">
         <source>+ Add Custom URL</source>
         <target>+ הוספת כתובת מותאמת אישית</target>
         <note>Label for button to add a custom URL with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.customDescriptoin">
         <source>Add and manage custom autocomplete URLs.</source>
         <target>הוספה וניהול של כתובות להשלמה בהתאמה אישית.</target>
         <note>Description for adding and managing custom autocomplete URLs</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.customLabel">
         <source>Custom URLs</source>
         <target>כתובות מותאמות אישית</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.customTitle">
         <source>CUSTOM URL LIST</source>
         <target>רשימת כתובות מותאמות אישית</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customUrlAdded" xml:space="preserve">
+      <trans-unit id="Autocomplete.customUrlAdded">
         <source>New Custom URL added.</source>
         <target>נוספה כתובת מותאמת אישית חדשה.</target>
         <note>Label for toast alerting a custom URL has been added</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultDescriptoin">
         <source>Enable to have %@ autocomplete over 450 popular URLs in the address bar.</source>
         <target>יש להפעיל לטובת השלמה אוטומטית של %@ בלמעלה מ־450 כתובות נפוצות בשורת הכתובת.</target>
         <note>Description for enabling or disabling the default list. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultLabel">
         <source>Autocomplete</source>
         <target>השלמה אוטומטית</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultTitle">
         <source>DEFAULT URL LIST</source>
         <target>רשימת כתובות ברירת מחדל</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.disabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.disabled">
         <source>Disabled</source>
         <target>מושבת</target>
         <note>label describing URL Autocomplete as disabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.duplicateUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.duplicateUrl">
         <source>URL already exists</source>
         <target>הכתובת כבר קיימת</target>
         <note>Label for toast alerting that the custom URL being added is a duplicate</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.emptyState" xml:space="preserve">
+      <trans-unit id="Autocomplete.emptyState">
         <source>No Custom URLs to display</source>
         <target>אין כתובת בהתאמה אישית להצגה</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.enabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.enabled">
         <source>Enabled</source>
         <target>פעיל</target>
         <note>label describing URL Autocomplete as enabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.manageSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.manageSites">
         <source>Manage Sites</source>
         <target>ניהול אתרים</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySites" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySites">
         <source>My Sites</source>
         <target>האתרים שלי</target>
         <note>Label for enabling or disabling autocomplete</note>
@@ -290,12 +289,12 @@
         <source>Enable to have %@ autocomplete your favorite URLs.</source>
         <note>Description for adding and managing custom autocomplete URLs. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.topSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.topSites">
         <source>Top Sites</source>
         <target>אתרים מובילים</target>
         <note>Label for enabling or disabling top sites</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.newSession" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.newSession">
         <source>New Session</source>
         <target>הפעלה חדשה</target>
         <note>Create a new session after failing a biometric check</note>
@@ -304,217 +303,217 @@
         <source>Unlock %@ when re-opening in order to prevent unauthorized access.</source>
         <note>%@ is app name. Explanation for why the app needs access to biometric information. Prompt is only shown once when the user first tries to enable Face ID to open the app.</note>
       </trans-unit>
-      <trans-unit id="Browser.backLabel" xml:space="preserve">
+      <trans-unit id="Browser.backLabel">
         <source>Back</source>
         <target>אחורה</target>
         <note>Accessibility label for the back button</note>
       </trans-unit>
-      <trans-unit id="Browser.copyAddressLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyAddressLabel">
         <source>Copy Address</source>
         <target>העתקת כתובת</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.copyMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyMenuLabel">
         <source>Copy</source>
         <target>העתקה</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.customURLMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.customURLMenuLabel">
         <source>Add Custom URL</source>
         <target>הוספת כתובת מותאמת אישית</target>
         <note>Custom URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.forwardLabel" xml:space="preserve">
+      <trans-unit id="Browser.forwardLabel">
         <source>Forward</source>
         <target>קדימה</target>
         <note>Accessibility label for the forward button</note>
       </trans-unit>
-      <trans-unit id="Browser.reloadLabel" xml:space="preserve">
+      <trans-unit id="Browser.reloadLabel">
         <source>Reload</source>
         <target>טעינה מחדש</target>
         <note>Accessibility label for the reload button</note>
       </trans-unit>
-      <trans-unit id="Browser.settingsLabel" xml:space="preserve">
+      <trans-unit id="Browser.settingsLabel">
         <source>Settings</source>
         <target>הגדרות</target>
         <note>Accessibility label for the settings button</note>
       </trans-unit>
-      <trans-unit id="Browser.shareLabel" xml:space="preserve">
+      <trans-unit id="Browser.shareLabel">
         <source>Share</source>
         <target>שיתוף</target>
         <note>Accessibility label for the share button</note>
       </trans-unit>
-      <trans-unit id="Browser.stopLabel" xml:space="preserve">
+      <trans-unit id="Browser.stopLabel">
         <source>Stop</source>
         <target>עצירה</target>
         <note>Accessibility label for the stop button</note>
       </trans-unit>
-      <trans-unit id="Cancel" xml:space="preserve">
+      <trans-unit id="Cancel">
         <source>Cancel</source>
         <target>ביטול</target>
         <note>Label on button to cancel edits</note>
       </trans-unit>
-      <trans-unit id="Done" xml:space="preserve">
+      <trans-unit id="Done">
         <source>Done</source>
         <target>סיום</target>
         <note>Label on button to complete edits</note>
       </trans-unit>
-      <trans-unit id="Edit" xml:space="preserve">
+      <trans-unit id="Edit">
         <source>Edit</source>
         <target>עריכה</target>
         <note>Label on button to allow edits</note>
       </trans-unit>
-      <trans-unit id="Error.tryAgainButton" xml:space="preserve">
+      <trans-unit id="Error.tryAgainButton">
         <source>Try again</source>
         <target>לנסות שוב</target>
         <note>Button label to reload the error page</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.cancelTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.cancelTitle">
         <source>Cancel</source>
         <target>ביטול</target>
         <note>Button label used for cancelling to open another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.messageTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.messageTitle">
         <source>%@ wants to open another App</source>
         <target>%@ רוצה לפתוח יישומון אחר</target>
         <note>Dialog title used for opening an external app from Focus. The placeholder string is the app name of either Focus or Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.openTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.openTitle">
         <source>Open</source>
         <target>פתיחה</target>
         <note>Button label for opening another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.callButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.callButton">
         <source>Call</source>
         <target>התקשרות</target>
         <note>Button label in tel: dialog to call a phone number. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.cancelButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.cancelButton">
         <source>Cancel</source>
         <target>ביטול</target>
         <note>Button label in external link dialog to cancel the dialog. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.emailButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.emailButton">
         <source>Email</source>
         <target>דוא״ל</target>
         <note>Button label in mailto: dialog to send an email. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.messageTitleWithPlaceholder" xml:space="preserve">
+      <trans-unit id="ExternalLink.messageTitleWithPlaceholder">
         <source>You are now leaving %@.</source>
         <target>אתם עוזבים כעת את %@.</target>
         <note>Dialog title used for Maps/App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreButton">
         <source>Open App Store</source>
         <target>פתיחת App Store</target>
         <note>Button label in App Store URL dialog to open the App Store. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreTitle" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreTitle">
         <source>%@ wants to open the App Store.</source>
         <target>%@ מבקש גישה אל ה־App Store.</target>
         <note>Dialog title used to open App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openMapsButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openMapsButton">
         <source>Open Maps</source>
         <target>פתיחת מפות</target>
         <note>Button label in Maps URL dialog to open Maps. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="FindInPage.Done" xml:space="preserve">
+      <trans-unit id="FindInPage.Done">
         <source>Find in page done</source>
         <target>החיפוש בדף הסתיים</target>
         <note>Accessibility label for done button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.NextResult" xml:space="preserve">
+      <trans-unit id="FindInPage.NextResult">
         <source>Find next in page</source>
         <target>חיפוש הבא בדף</target>
         <note>Accessibility label for next result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.PreviousResult" xml:space="preserve">
+      <trans-unit id="FindInPage.PreviousResult">
         <source>Find previous in page</source>
         <target>חיפוש הקודם בדף</target>
         <note>Accessibility label for previous result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FirstRun.lastSlide.buttonLabel" xml:space="preserve">
+      <trans-unit id="FirstRun.lastSlide.buttonLabel">
         <source>OK, Got It!</source>
         <target>בסדר, הבנתי!</target>
         <note>Label on button to dismiss first run UI</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelDescription" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelDescription">
         <source>Automatically block online trackers while you browse. Then tap to erase visited pages, searches, cookies and passwords from your device.</source>
         <target>חסימת מעקב מקוון אוטומטית במהלך הגלישה שלך, ואז מחיקת רשימת האתרים שביקרת בהם, חיפושים, עוגיות וססמאות מההתקן שלך.</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelTagline" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelTagline">
         <source>Browse like no one’s watching.</source>
         <target>גלישה כאילו אף־אחד אינו צופה בך.</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="Focus.handoffSyncing" xml:space="preserve">
+      <trans-unit id="Focus.handoffSyncing">
         <source>Apple Handoff is syncing</source>
         <target>Handoff מבית Apple מסתנכרן</target>
         <note>Title for the loading screen when the handoff of clipboard delays Focus launch. “Handoff” should not be localized, see https://support.apple.com/HT204681</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel1" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel1">
         <source>Automatic private browsing.</source>
         <target>גלישה פרטית אוטומטית.</target>
         <note>First label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel2" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel2">
         <source>Browse. Erase. Repeat.</source>
         <target>גלישה, מחיקה, חזרה להתחלה.</target>
         <note>Second label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Menu.Close" xml:space="preserve">
+      <trans-unit id="Menu.Close">
         <source>Close</source>
         <target>סגירה</target>
         <note>Button label used to close a menu that displays as a popup.</note>
       </trans-unit>
-      <trans-unit id="Open.Cancel" xml:space="preserve">
+      <trans-unit id="Open.Cancel">
         <source>Cancel</source>
         <target>ביטול</target>
         <note>Label in share alert to cancel the alert</note>
       </trans-unit>
-      <trans-unit id="Open.Firefox" xml:space="preserve">
+      <trans-unit id="Open.Firefox">
         <source>Firefox (Private Browsing)</source>
         <target>Firefox (גלישה פרטית)</target>
         <note>Label in share alert to open the URL in Firefox</note>
       </trans-unit>
-      <trans-unit id="Open.More" xml:space="preserve">
+      <trans-unit id="Open.More">
         <source>More</source>
         <target>עוד</target>
         <note>Label in share alert to open the full system share menu</note>
       </trans-unit>
-      <trans-unit id="Open.Safari" xml:space="preserve">
+      <trans-unit id="Open.Safari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Label in share alert to open the URL in Safari</note>
       </trans-unit>
-      <trans-unit id="Request Desktop Site" xml:space="preserve">
+      <trans-unit id="Request Desktop Site">
         <source>Request Desktop Site</source>
         <target>בקשת אתר שולחני</target>
         <note>Label for button that requests the desktop version of the currently loaded website.</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsContentBlockers" xml:space="preserve">
+      <trans-unit id="Safari.instructionsContentBlockers">
         <source>Tap Safari, then select Content Blockers</source>
         <target>יש להיכנס ל־Safari ולבחור בחוסמי תוכן</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsEnable" xml:space="preserve">
+      <trans-unit id="Safari.instructionsEnable">
         <source>Enable %@</source>
         <target>הפעלת %@</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsNotEnabled" xml:space="preserve">
+      <trans-unit id="Safari.instructionsNotEnabled">
         <source>%@ is not enabled.</source>
         <target>u200f%@ לא מופעל.</target>
         <note>Error label when the blocker is not enabled, shown in the intro and main app when disabled</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsOpen" xml:space="preserve">
+      <trans-unit id="Safari.instructionsOpen">
         <source>Open Settings App</source>
         <target>פתחו את היישום הגדרות</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Save" xml:space="preserve">
+      <trans-unit id="Save">
         <source>Save</source>
         <target>שמירה</target>
         <note>Save button label</note>
@@ -523,167 +522,167 @@
         <source>That didn't work. Try replacing the search term with this: %s.</source>
         <note>Label for error state when entering an invalid search engine URL. %s is a search term in a URL.</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptDisable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptDisable">
         <source>No</source>
         <target>לא</target>
         <note>Label for disable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptEnable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptEnable">
         <source>Yes</source>
         <target>כן</target>
         <note>Label for enable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptMessage" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptMessage">
         <source>To get suggestions, %@ needs to send what you type in the address bar to the search engine.</source>
         <target>כדי לקבל הצעות, על %@ לשלוח מה שמוקלד בשורת הכתובת אל מנוע החיפוש.</target>
         <note>%@ is the name of the app (Focus / Klar). Label for search suggestions prompt message</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptTitle" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptTitle">
         <source>Show Search Suggestions?</source>
         <target>להציג הצעות חיפוש?</target>
         <note>Title for search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButton" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButton">
         <source>Add Another Search Engine</source>
         <target>הוספת מנוע חיפוש נוסף</target>
         <note>Text for button to add another search engine in settings</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus">
         <source>+ Add Another Search Engine</source>
         <target>+ הוספת מנוע חיפוש נוסף</target>
         <note>Text for button to add another search engine in settings with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineTitle" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineTitle">
         <source>Add Search Engine</source>
         <target>הוספת מנוע חיפוש</target>
         <note>Title on add search engine settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.InstalledSearchEngines" xml:space="preserve">
+      <trans-unit id="Settings.Search.InstalledSearchEngines">
         <source>INSTALLED SEARCH ENGINES</source>
         <target>מנועי חיפוש מותקנים</target>
         <note>Header for rows of installed search engines</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NameToDisplay" xml:space="preserve">
+      <trans-unit id="Settings.Search.NameToDisplay">
         <source>Name to display</source>
         <target>שם להצגה</target>
         <note>Label for input field for the name of the search engine to be added</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NewSearchEngineAdded" xml:space="preserve">
+      <trans-unit id="Settings.Search.NewSearchEngineAdded">
         <source>New Search Engine Added.</source>
         <target>נוסף מנוע חיפוש חדש.</target>
         <note>Toast displayed after adding a search engine</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.RestoreEngine" xml:space="preserve">
+      <trans-unit id="Settings.Search.RestoreEngine">
         <source>Restore Default Search Engines</source>
         <target>שחזור מנועי חיפוש ברירת מחדל</target>
         <note>Label for button to bring deleted default engines back</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchEngineName" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchEngineName">
         <source>Search engine name</source>
         <target>שם מנוע החיפוש</target>
         <note>Placeholder text for input of new search engine name</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplate" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplate">
         <source>Search string to use</source>
         <target>מחרוזת חיפוש לשימוש</target>
         <note>Label for input of search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplatePlaceholder" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplatePlaceholder">
         <source>Paste or enter search string. If necessary, replace search term with: %s.</source>
         <target>יש להדביק או להקליד מחרוזת לחיפוש. במידת הצורך, יש להחליף את הביטוי לחיפוש ב־: %s.</target>
         <note>Placeholder text for input of new search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.autocompleteSection" xml:space="preserve">
+      <trans-unit id="Settings.autocompleteSection">
         <source>URL Autocomplete</source>
         <target>השלמת כתובת אוטומטית</target>
         <note>Title for the URL Autocomplete row</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherMessage" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherMessage">
         <source>Blocking other content trackers may break some videos and web pages.</source>
         <target>חסימת רכיבי מעקב אחרים עלולה לשבש את פעילותם של דפי אינטרנט ומספר סרטונים.</target>
         <note>Alert message shown when toggling the Content blocker</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherNo2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherNo2">
         <source>Cancel</source>
         <target>ביטול</target>
         <note>Button label for declining Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherYes2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherYes2">
         <source>Block Content Trackers</source>
         <target>חסימת רכיבי מעקב של תוכן</target>
         <note>Button label for accepting Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSearchSuggestion" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSearchSuggestion">
         <source>%@ will send what you type in the address bar to your search engine.</source>
         <target>‏%@ ישלח מה שיוקלד בשורת הכתובת אל מנוע החיפוש שלך.</target>
         <note>Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSendUsageData">
         <source>Mozilla strives to collect only what we need to provide and improve %@ for everyone.</source>
         <target>Mozilla חותרת לאסוף רק מה שנדרש לצורך שיפור %@ לטובת הכלל.</target>
         <note>Description associated to the Send Usage Data toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.learnMore" xml:space="preserve">
+      <trans-unit id="Settings.learnMore">
         <source>Learn more.</source>
         <target>מידע נוסף.</target>
         <note>Subtitle for Send Anonymous Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.rate" xml:space="preserve">
+      <trans-unit id="Settings.rate">
         <source>Rate %@</source>
         <target>דירוג %@</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, allows the user to leave a review for the app on the app store.</note>
       </trans-unit>
-      <trans-unit id="Settings.safariTitle" xml:space="preserve">
+      <trans-unit id="Settings.safariTitle">
         <source>SAFARI INTEGRATION</source>
         <target>שילוב עם Safari</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.screenTitle" xml:space="preserve">
+      <trans-unit id="Settings.screenTitle">
         <source>Settings</source>
         <target>הגדרות</target>
         <note>Title for settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchLabel" xml:space="preserve">
+      <trans-unit id="Settings.searchLabel">
         <source>Search Engine</source>
         <target>מנוע חיפוש</target>
         <note>Label for the search engine in the search screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchSuggestions" xml:space="preserve">
+      <trans-unit id="Settings.searchSuggestions">
         <source>Get Search Suggestions</source>
         <target>קבלת הצעות חיפוש</target>
         <note>Label for the Search Suggestions toggle row</note>
       </trans-unit>
-      <trans-unit id="Settings.searchTitle2" xml:space="preserve">
+      <trans-unit id="Settings.searchTitle2">
         <source>SEARCH</source>
         <target>חיפוש</target>
         <note>Title for the search selection screen</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionIntegration" xml:space="preserve">
+      <trans-unit id="Settings.sectionIntegration">
         <source>INTEGRATION</source>
         <target>הטמעה</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionMozilla" xml:space="preserve">
+      <trans-unit id="Settings.sectionMozilla">
         <source>MOZILLA</source>
         <target>MOZILLA</target>
         <note>Section label for Mozilla toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPerformance" xml:space="preserve">
+      <trans-unit id="Settings.sectionPerformance">
         <source>PERFORMANCE</source>
         <target>ביצועים</target>
         <note>Section label for performance toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPrivacy" xml:space="preserve">
+      <trans-unit id="Settings.sectionPrivacy">
         <source>PRIVACY</source>
         <target>פרטיות</target>
         <note>Section label for privacy toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionSecurity" xml:space="preserve">
+      <trans-unit id="Settings.sectionSecurity">
         <source>SECURITY</source>
         <target>אבטחה</target>
         <note>Header label for security toggles displayed in the settings menu</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAds2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAds2">
         <source>Advertising</source>
         <target>פרסום</target>
         <note>Label for the checkbox to toggle Advertising trackers</note>
@@ -692,377 +691,397 @@
         <source>Analytics</source>
         <note>Label for the checkbox to toggle Analytics trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockFonts" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockFonts">
         <source>Block web fonts</source>
         <target>חסימת גופני רשת</target>
         <note>Label for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockOther2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockOther2">
         <source>Content</source>
         <target>תוכן</target>
         <note>Label for the checkbox to toggle Other trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockSocial2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockSocial2">
         <source>Social</source>
         <target>רשתות חברתיות</target>
         <note>Label for the checkbox to toggle Social trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceID" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceID">
         <source>Use Face ID to unlock app</source>
         <target>שימוש ב־Face ID כדי לשחרר את נעילת היישומון</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceIDDescription">
         <source>Face ID can unlock %@ if a URL is already open in the app</source>
         <target>u200fFace ID יכול לשחרר את הנעילה של %@ אם כתובת אתר כבר פתוחה ביישומון</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Face ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleHomeScreenTips" xml:space="preserve">
+      <trans-unit id="Settings.toggleHomeScreenTips">
         <source>Show home screen tips</source>
         <target>הצגת עצות במסך הבית</target>
         <note>Show home screen tips toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleOtherSubtitle" xml:space="preserve">
+      <trans-unit id="Settings.toggleOtherSubtitle">
         <source>May break some videos and Web pages</source>
         <target>עלולה לשבש את פעילותם של דפי אינטרנט ומספר סרטונים</target>
         <note>Label subtitle for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSafari" xml:space="preserve">
+      <trans-unit id="Settings.toggleSafari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Safari toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.toggleSendUsageData">
         <source>Send usage data</source>
         <target>שליחת נתוני שימוש</target>
         <note>Label for Send Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchID" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchID">
         <source>Use Touch ID to unlock app</source>
         <target>שימוש ב־Touch ID כדי לשחרר את נעילת היישומון</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchIDDescription">
         <source>Touch ID can unlock %@ if a URL is already open in the app</source>
         <target>u200fTouch ID יכול לשחרר את הנעילה של %@ אם כתובת אתר כבר פתוחה ביישומון</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Touch ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOff" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOff">
         <source>Off</source>
         <target>כבוי</target>
         <note>Status off for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOn" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOn">
         <source>On</source>
         <target>פעיל</target>
         <note>Status on for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.whatsNewTitle" xml:space="preserve">
+      <trans-unit id="Settings.whatsNewTitle">
         <source>What’s New</source>
         <target>מה חדש</target>
         <note>Title for What's new screen</note>
       </trans-unit>
-      <trans-unit id="Settinsg.siriShortcutsTitle" xml:space="preserve">
+      <trans-unit id="Settinsg.siriShortcutsTitle">
         <source>SIRI SHORTCUTS</source>
         <target>קיצורי דרך ל־Siri</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.FindInPage" xml:space="preserve">
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>חיפוש בדף</target>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.GetFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.GetFirefox">
         <source>Get the Firefox App</source>
         <target>קבלו את Firefox</target>
         <note>Text for the share menu option when a user wants to open a page in Firefox but doesn’t have it installed. This string will not wrap in the interface. Instead, it will truncate. To prevent this, please keep the localized string to 18 or fewer characters. If your string runs longer than 18 characters, you can use 'Get Firefox' as the basis for your string. However, if at all possible, we’d like to signal to the user that they will be going to the App Store and installing the application from there. That is why we are using Get and App in the en-US string.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.PageActions" xml:space="preserve">
+      <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <target>פעולות דף</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestDesktop" xml:space="preserve">
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
         <target>בקשת אתר שולחני</target>
         <note>Text for the share menu option when a user wants to reload the site as a desktop</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestMobile" xml:space="preserve">
+      <trans-unit id="ShareMenu.RequestMobile">
         <source>Request Mobile Site</source>
         <target>בקשת אתר מותאם לנייד</target>
         <note>Text for the share menu option when a user wants to reload the site as a mobile device</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenChrome" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenChrome">
         <source>Open in Chrome</source>
         <target>פתיחה ב־Chrome</target>
         <note>Text for the share menu option when a user wants to open the current website in the Chrome app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenFirefox">
         <source>Open in Firefox</source>
         <target>פתיחה ב־Firefox</target>
         <note>Text for the share menu option when a user wants to open the current website in the Firefox app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenSafari" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenSafari">
         <source>Open in Safari</source>
         <target>פתיחה ב־Safari</target>
         <note>Text for the share menu option when a user wants to open the current website in the Safari app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.SharePage" xml:space="preserve">
+      <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <target>שיתוף הדף עם...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
       </trans-unit>
-      <trans-unit id="Siri.add" xml:space="preserve">
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
+      </trans-unit>
+      <trans-unit id="Siri.add">
         <source>Add</source>
         <target>הוספה</target>
         <note>Button to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.addTo" xml:space="preserve">
+      <trans-unit id="Siri.addTo">
         <source>Add to Siri</source>
         <target>הוספה ל־Siri</target>
         <note>Button to add a specified shortcut option to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.editOpenUrl" xml:space="preserve">
+      <trans-unit id="Siri.editOpenUrl">
         <source>Re-Record or Delete Shortcut</source>
         <target>הקלטה מחדש או מחיקה של קיצור דרך</target>
         <note>Label for button to edit the Siri phrase or delete the Siri functionality.</note>
       </trans-unit>
-      <trans-unit id="Siri.erase" xml:space="preserve">
+      <trans-unit id="Siri.erase">
         <source>Erase</source>
         <target>מחיקה</target>
         <note>Title of option in settings to set up Siri to erase</note>
       </trans-unit>
-      <trans-unit id="Siri.eraseAndOpen" xml:space="preserve">
+      <trans-unit id="Siri.eraseAndOpen">
         <source>Erase &amp; Open</source>
         <target>מחיקה ופתיחה</target>
         <note>Title of option in settings to set up Siri to erase and then open the app.</note>
       </trans-unit>
-      <trans-unit id="Siri.favoriteUrl" xml:space="preserve">
+      <trans-unit id="Siri.favoriteUrl">
         <source>Open Favorite Site</source>
         <target>פתיחת אתר מועדף</target>
         <note>Title for screen to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.openURL" xml:space="preserve">
+      <trans-unit id="Siri.openURL">
         <source>Open Favorite Site</source>
         <target>פתיחת אתר מועדף</target>
         <note>Title of option in settings to set up Siri to open a specified URL in Focus/Klar.</note>
       </trans-unit>
-      <trans-unit id="Siri.urlToOpen" xml:space="preserve">
+      <trans-unit id="Siri.urlToOpen">
         <source>URL to open</source>
         <target>כתובת לפתיחה</target>
         <note>Label for input to set a favorite URL to be opened by Siri.</note>
       </trans-unit>
-      <trans-unit id="URL.addToAutocompleteLabel" xml:space="preserve">
+      <trans-unit id="URL.addToAutocompleteLabel">
         <source>Add link to autocomplete</source>
         <target>הוספת קישור להשלמה אוטומטית</target>
         <note>Label displayed for button used as a shortcut to add a link to the list of URLs to autocomplete.</note>
       </trans-unit>
-      <trans-unit id="URL.cancelLabel" xml:space="preserve">
+      <trans-unit id="URL.cancelLabel">
         <source>Cancel</source>
         <target>ביטול</target>
         <note>Label for cancel button shown when entering a URL or search</note>
       </trans-unit>
-      <trans-unit id="URL.contextMenu" xml:space="preserve">
+      <trans-unit id="URL.contextMenu">
         <source>Paste &amp; Go</source>
         <target>הדבקה ומעבר</target>
         <note>Text for the URL context menu when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.eraseButtonLabel" xml:space="preserve">
+      <trans-unit id="URL.eraseButtonLabel">
         <source>ERASE</source>
         <target>מחיקה</target>
         <note>Erase button in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.eraseMessageLabel2" xml:space="preserve">
+      <trans-unit id="URL.eraseMessageLabel2">
         <source>Browsing history cleared</source>
         <target>היסטוריית הגלישה נמחקה</target>
         <note>Message shown after pressing the Erase button</note>
       </trans-unit>
-      <trans-unit id="URL.findOnPageLabel" xml:space="preserve">
+      <trans-unit id="URL.findOnPageLabel">
         <source>Find in page: %@</source>
         <target>חיפוש בדף: %@</target>
         <note>Label displayed for find in page button when typing in the URL Bar. %@ is any text the user has typed into the URL bar that they want to find on the current page.</note>
       </trans-unit>
-      <trans-unit id="URL.paste" xml:space="preserve">
+      <trans-unit id="URL.paste">
         <source>Paste</source>
         <target>הדבקה</target>
         <note>Text for a menu displayed from the bottom of the screen when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.placeholderText" xml:space="preserve">
+      <trans-unit id="URL.placeholderText">
         <source>Search or enter address</source>
         <target>חיפוש או הכנסת כתובת</target>
         <note>Placeholder text shown in the URL bar before the user navigates to a page</note>
       </trans-unit>
-      <trans-unit id="URL.searchLabel" xml:space="preserve">
+      <trans-unit id="URL.searchLabel">
         <source>Search for %@</source>
         <target>חיפוש אחר %@</target>
         <note>Label displayed for search button when typing in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="URL.trackersBlockedLabel">
         <source>Trackers blocked</source>
         <target>רכיבי מעקב חסומים</target>
         <note>Text for the URL bar showing the number of trackers blocked on a webpage.</note>
       </trans-unit>
-      <trans-unit id="actionSheet.openIn" xml:space="preserve">
+      <trans-unit id="actionSheet.openIn">
         <source>Open in %@</source>
         <target>פתיחה ב־%@</target>
         <note>Title for action sheet item to open the current page in another application. Placeholder is the name of the application to open the current page.</note>
       </trans-unit>
-      <trans-unit id="browser.copyAddressToast" xml:space="preserve">
+      <trans-unit id="browser.copyAddressToast">
         <source>URL Copied To Clipboard</source>
         <target>הכתובת הועתקה ללוח העריכה</target>
         <note>Toast displayed after a URL has been copied to the clipboard</note>
       </trans-unit>
-      <trans-unit id="browserShortcutDescription.selectLocationBar" xml:space="preserve">
+      <trans-unit id="browserShortcutDescription.selectLocationBar">
         <source>Select Location Bar</source>
         <target>בחירת סרגל מיקום</target>
         <note>Label to display in the Discoverability overlay for keyboard shortcuts</note>
       </trans-unit>
-      <trans-unit id="contextMenu.clipboardLink" xml:space="preserve">
+      <trans-unit id="contextMenu.clipboardLink">
         <source>Link you copied: %@</source>
         <target>קישור שהעתקת: %@</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.copyImageTitle">
         <source>Copy Image</source>
         <target>העתקת תמונה</target>
         <note>Text for the context menu when a user wants to copy an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyLink" xml:space="preserve">
+      <trans-unit id="contextMenu.copyLink">
         <source>Copy Link</source>
         <target>העתקת קישור</target>
         <note>Text for the context menu when a user wants to copy a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.linkCopied" xml:space="preserve">
+      <trans-unit id="contextMenu.linkCopied">
         <source>Link you copied: </source>
         <target>הקישור שהעתקת:</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.saveImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.saveImageTitle">
         <source>Save Image</source>
         <target>שמירת תמונה</target>
         <note>Text for the context menu when a user wants to save an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.shareLinkTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.shareLinkTitle">
         <source>Share Link</source>
         <target>שיתוף קישור</target>
         <note>Text for the context menu when a user wants to share a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="externalAppLinkWithAppName.messageTitle" xml:space="preserve">
+      <trans-unit id="externalAppLinkWithAppName.messageTitle">
         <source>%1$@ wants to open %2$@</source>
         <target>%1$@ רוצה לפתוח את %2$@</target>
         <note>Dialog title used for opening an external app from Focus. First placeholder string is the app name of either Focus or Klar and the second placeholder string specifies the app it wants to open.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.description" xml:space="preserve">
+      <trans-unit id="photosPermission.description">
         <source>This lets you save images to your Camera Roll</source>
         <target>אפשרות זו מאפשרת לשמור תמונות אל ה־Camera Roll</target>
         <note>Description for dialog used for requesting a user to enable access to Photos.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.openSettings" xml:space="preserve">
+      <trans-unit id="photosPermission.openSettings">
         <source>Open Settings</source>
         <target>פתיחת הגדרות</target>
         <note>Title for button that takes the user to system settings</note>
       </trans-unit>
-      <trans-unit id="photosPermission.title" xml:space="preserve">
+      <trans-unit id="photosPermission.title">
         <source>“%@” Would Like to Access Your Photos</source>
         <target>ל־“%@” נדרשת גישה אל התמונות שלך</target>
         <note>Dialog title used for requesting a user to enable access to Photos. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="settings.Search.SearchTemplateExample" xml:space="preserve">
+      <trans-unit id="settings.Search.SearchTemplateExample">
         <source>Example: searchengineexample.com/search/?q=%s</source>
         <target>דוגמה: searchengineexample.com/search/?q=%s</target>
         <note>Text displayed as an example of the template to add a search engine.</note>
       </trans-unit>
-      <trans-unit id="share" xml:space="preserve">
+      <trans-unit id="share">
         <source>Share</source>
         <target>שיתוף</target>
         <note>Text for a share button</note>
       </trans-unit>
-      <trans-unit id="shareMenu.copyAddress" xml:space="preserve">
+      <trans-unit id="shareMenu.copyAddress">
         <source>Copy Address</source>
         <target>העתקת כתובת</target>
         <note>Text for the share menu when a user wants to copy a URL.</note>
       </trans-unit>
-      <trans-unit id="touchId.reason" xml:space="preserve">
+      <trans-unit id="touchId.reason">
         <source>Use Touch ID to return to %@</source>
         <target>יש להשתמש ב־Touch ID כדי לחזור אל %@</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.adTrackersLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.adTrackersLabel">
         <source>Ad trackers</source>
         <target>עוקבי פרסומות</target>
         <note>Label for ad trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.analyticTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.analyticTrackerLabel">
         <source>Analytic trackers</source>
         <target>עוקבי ניתוח נתונים</target>
         <note>label for analytic trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.contentTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>
         <target>עוקבי תוכן</target>
         <note>label for content trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.disabledLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.disabledLabel">
         <source>Tracking Protection off</source>
         <target>הגנת מעקב כבויה</target>
         <note>text showing the tracking protection is disabled.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.label" xml:space="preserve">
+      <trans-unit id="trackingProtection.label">
         <source>Tracking Protection</source>
         <target>הגנת מעקב</target>
         <note>Title for the tracking settings page to change what trackers are blocked.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.labelDescription" xml:space="preserve">
+      <trans-unit id="trackingProtection.labelDescription">
         <source>Turning this off may fix some site problems</source>
         <target>כיבוי אפשרות זו עשוי לתקן בעיות מסוימות באתרים</target>
         <note>Description/subtitle for the tracking protection label.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.learnMore" xml:space="preserve">
+      <trans-unit id="trackingProtection.learnMore">
         <source>Learn More</source>
         <target>מידע נוסף</target>
         <note>Text for the button to learn more about Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.moreSettings" xml:space="preserve">
+      <trans-unit id="trackingProtection.moreSettings">
         <source>More Settings</source>
         <target>הגדרות נוספות</target>
         <note>Text for the button that closes the Shield Data and opens the regular Settings screen.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.socialTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.socialTrackerLabel">
         <source>Social trackers</source>
         <target>עוקבים חברתיים</target>
         <note>label for social trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOff" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOff">
         <source>Protections are OFF for this session</source>
         <target>ההגנות כבויות עבור הפעלה זו</target>
         <note>Text for the status off from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOn" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOn">
         <source>Protections are ON for this session</source>
         <target>ההגנות פעילות עבור הפעלה זו</target>
         <note>Text for the status on from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleDescription1" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleDescription1">
         <source>Disable until you close %@ or tap ERASE.</source>
         <target>ניטרול עד לסגירת %@ או לחיצה על מחיקה.</target>
         <note>Description for the tracking protection toggle. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleLabel2">
         <source>Enhanced Tracking Protection</source>
         <target>הגנת מעקב מתקדמת</target>
         <note>Text for the toggle that enables/disables tracking protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackerDescriptionLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackerDescriptionLabel2">
         <source>Keep your data to yourself. %@ protects you from many of the most common trackers that follow what you do online.</source>
         <target>הנתונים שלך נשארים אצלך. %@ מגן עליך מפני רוב רכיבי הריגול שעוקבים אחר הפעילות המקוונת שלך.</target>
         <note>General description of tracking protection settings, which is displayed underneath the trackers preferences in Settings. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersBlockedLabel">
         <source>Trackers blocked since %@</source>
         <target>רכיבי מעקב חסומים מאז %@</target>
         <note>Text for tracking protection screen showing the number of trackers blocked since the app install. The placeholder is replaced with the install date of the application.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersHeader" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersHeader">
         <source>Trackers and scripts to block</source>
         <target>רכיבי מעקב ותסריטים לחסימה</target>
         <note>Text for the header of trackers section from Tracking Protection.</note>
@@ -1074,7 +1093,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="SettingsBundle.Licenses" xml:space="preserve">
+      <trans-unit id="SettingsBundle.Licenses">
         <source>Licenses</source>
         <target>רישיונות</target>
         <note>The title of the Licenses setting in the settings that Focus shows in the global iOS Settings app.</note>
@@ -1082,3 +1101,4 @@
     </body>
   </file>
 </xliff>
+

--- a/hi-IN/focus-ios.xliff
+++ b/hi-IN/focus-ios.xliff
@@ -754,6 +754,10 @@
         <target>SIRI शॉर्टकट</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>पृष्ठ में ढूँढें</target>
@@ -768,6 +772,10 @@
         <source>Page Actions</source>
         <target>पृष्ठ क्रियाएँ</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -797,6 +805,10 @@
         <source>Share Page With...</source>
         <target>के साथ पृष्ठ साझा करें…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -981,6 +993,14 @@
         <source>Analytic trackers</source>
         <target>विश्लेषणात्मक ट्रैकर्स</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/hsb/focus-ios.xliff
+++ b/hsb/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>SIRI SHORTCUTS</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Na stronje pytać</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>Akcije strony</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>Stronu dźělić z...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>Amalyzowe přesćěhowaki</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/hu/focus-ios.xliff
+++ b/hu/focus-ios.xliff
@@ -1,36 +1,35 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Blockzilla/en.lproj/InfoPlist.strings" source-language="en" target-language="hu" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="NSCameraUsageDescription" xml:space="preserve">
+      <trans-unit id="NSCameraUsageDescription">
         <source>This lets you take and upload photos.</source>
         <target>Ez lehetővé teszi, hogy fényképeket készítsen és töltsön fel.</target>
         <note>Privacy - Camera Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSFaceIDUsageDescription" xml:space="preserve">
+      <trans-unit id="NSFaceIDUsageDescription">
         <source>This lets you unlock the app.</source>
         <target>Ezzel kinyithatja az alkalmazást.</target>
         <note>Privacy - Face ID Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSLocationWhenInUseUsageDescription" xml:space="preserve">
+      <trans-unit id="NSLocationWhenInUseUsageDescription">
         <source>Websites you visit may request your location.</source>
         <target>A meglátogatott webhelyek kérhetik az Ön helyét.</target>
         <note>Privacy - Location When In Use Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSMicrophoneUsageDescription" xml:space="preserve">
+      <trans-unit id="NSMicrophoneUsageDescription">
         <source>This lets you take and upload videos.</source>
         <target>Ez lehetővé teszi, hogy videókat készítsen és töltsön fel.</target>
         <note>Privacy - Microphone Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSPhotoLibraryAddUsageDescription" xml:space="preserve">
+      <trans-unit id="NSPhotoLibraryAddUsageDescription">
         <source>This lets you save and upload photos.</source>
         <target>Ez lehetővé teszi, hogy fényképeket mentsen és töltsön fel.</target>
         <note>Privacy - Photo Library Additions Usage Description</note>
       </trans-unit>
-      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen" xml:space="preserve">
+      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen">
         <source>Erase and Open</source>
         <target>Törlés és megnyitás</target>
         <note>This is the menu item that appears when you long press the Focus icon on the phone home screen.</note>
@@ -42,7 +41,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intents.Erase.Title" xml:space="preserve">
+      <trans-unit id="Intents.Erase.Title">
         <source>Erase</source>
         <target>Törlés</target>
         <note>Title of the Erase intent.</note>
@@ -54,42 +53,42 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intro.Slides.History.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Description">
         <source>Clear your entire browsing session history, passwords, cookies anytime with a single tap.</source>
         <target>Törölje az összes böngészési előzményét, jelszavát, és sütijét bármikor, egyetlen koppintással.</target>
         <note>Description for the 'History' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.History.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Title">
         <source>Your history is history</source>
         <target>Az előzményei történelem</target>
         <note>Title for the third  panel 'History' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Next.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Next.Button">
         <source>Next</source>
         <target>Tovább</target>
         <note>Button to go to the next card in Focus onboarding.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Description">
         <source>Searching for something different? Choose a different search engine.</source>
         <target>Valami mást keres? Válasszon másik keresőmotort.</target>
         <note>Description for the 'Favorite Search Engine' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Title">
         <source>Your search, your way</source>
         <target>Az Ön keresése, az Ön útja</target>
         <note>Title for the second  panel 'Search' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Skip.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Skip.Button">
         <source>Skip</source>
         <target>Kihagyás</target>
         <note>Button to skip onboarding in Focus</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Description">
         <source>Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times.</source>
         <target>Emelje a privát a böngészést a következő szintre. Blokkolja a hirdetéseket, és más tartalmakat, amelyek követhetik az oldalak között, és lelassíthatják a betöltési sebességet.</target>
         <note>Description for the 'Welcome' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Title">
         <source>Power up your privacy</source>
         <target>Tuningolja fel az adatvédelmét</target>
         <note>Title for the first panel 'Welcome' in the First Run tour.</note>
@@ -101,972 +100,992 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="About.learnMoreButton" xml:space="preserve">
+      <trans-unit id="About.learnMoreButton">
         <source>Learn more</source>
         <target>Tudjon meg többet</target>
         <note>Button on About screen</note>
       </trans-unit>
-      <trans-unit id="About.missionLabel" xml:space="preserve">
+      <trans-unit id="About.missionLabel">
         <source>%@ is produced by Mozilla. Our mission is to foster a healthy, open Internet.</source>
         <target>A %@ böngészőt a Mozilla készíti. Küldetésünk az egészséges, nyílt internet támogatása.</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet1" xml:space="preserve">
+      <trans-unit id="About.privateBullet1">
         <source>Search and browse right in the app</source>
         <target>Keressen és böngésszen közvetlenül az appban</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet2" xml:space="preserve">
+      <trans-unit id="About.privateBullet2">
         <source>Block trackers (or update settings to allow trackers)</source>
         <target>Blokkolja a követőket (vagy módosítsa a beállításokat az engedélyezéshez)</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet3" xml:space="preserve">
+      <trans-unit id="About.privateBullet3">
         <source>Erase to delete cookies as well as search and browsing history</source>
         <target>Törölje a sütiket is a keresési és böngészési előzményekkel</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBulletHeader" xml:space="preserve">
+      <trans-unit id="About.privateBulletHeader">
         <source>Use it as a private browser:</source>
         <target>Használja privát böngészőként:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowHelp" xml:space="preserve">
+      <trans-unit id="About.rowHelp">
         <source>Help</source>
         <target>Súgó</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowPrivacy" xml:space="preserve">
+      <trans-unit id="About.rowPrivacy">
         <source>Privacy Notice</source>
         <target>Adatvédelmi nyilatkozat</target>
         <note>Link to Privacy Notice in the About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowRights" xml:space="preserve">
+      <trans-unit id="About.rowRights">
         <source>Your Rights</source>
         <target>Az Ön jogai</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet1" xml:space="preserve">
+      <trans-unit id="About.safariBullet1">
         <source>Block trackers for improved privacy</source>
         <target>Blokkolja a követőket a nagyobb magánszféra érdekében</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet2" xml:space="preserve">
+      <trans-unit id="About.safariBullet2">
         <source>Block web fonts to reduce page size</source>
         <target>Blokkolja a webes betűkészleteket az oldalméret csökkentése érdekében</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBulletHeader" xml:space="preserve">
+      <trans-unit id="About.safariBulletHeader">
         <source>Use it as a Safari extension:</source>
         <target>Használja Safari bővítményként:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.title" xml:space="preserve">
+      <trans-unit id="About.title">
         <source>About %@</source>
         <target>A %@ névjegye</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, takes the user to a page with information about the product. Also displayed as a header for the About page.</note>
       </trans-unit>
-      <trans-unit id="About.topLabel" xml:space="preserve">
+      <trans-unit id="About.topLabel">
         <source>%@ puts you in control.</source>
         <target>A %@ visszaadja a kezébe az irányítást.</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Dismiss" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Dismiss">
         <source>Ok</source>
         <target>Rendben</target>
         <note>Button to dismiss the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Message" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Message">
         <source>An error occured while adding the pass to Wallet. Please try again later.</source>
         <target>Hiba történt a jegy Wallethez adása során. Próbálja újra később.</target>
         <note>Message of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Title" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Title">
         <source>Failed to Add Pass</source>
         <target>A jegy hozzáadása sikertelen</target>
         <note>Title of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="Authentication.reason" xml:space="preserve">
+      <trans-unit id="Authentication.reason">
         <source>Authenticate to return to %@</source>
         <target>Hitelesítsen a %@hoz visszatéréshez</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID, Face ID, or passcode to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrl">
         <source>Add Custom URL</source>
         <target>Egyéni URL hozzáadása</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlError" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlError">
         <source>Double-check the URL you entered.</source>
         <target>Ellenőrizze a megadott URL-t.</target>
         <note>Label for error state when entering an invalid URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlExample" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlExample">
         <source>Example: example.com</source>
         <target>Példa: example.com</target>
         <note>A label displaying an example URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlLabel">
         <source>URL to add</source>
         <target>Hozzáadandó URL</target>
         <note>Label for the input to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlPlaceholder" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlPlaceholder">
         <source>Paste or enter URL</source>
         <target>Illessze be, vagy adja meg az URL-t</target>
         <note>Placeholder for the input field to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlWithPlus" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlWithPlus">
         <source>+ Add Custom URL</source>
         <target>+ Egyéni URL hozzáadása</target>
         <note>Label for button to add a custom URL with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.customDescriptoin">
         <source>Add and manage custom autocomplete URLs.</source>
         <target>Automatikusan kiegészített URL-ek hozzáadása és kezelése.</target>
         <note>Description for adding and managing custom autocomplete URLs</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.customLabel">
         <source>Custom URLs</source>
         <target>Egyéni URL-ek</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.customTitle">
         <source>CUSTOM URL LIST</source>
         <target>EGYÉNI URL-EK LISTÁJA</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customUrlAdded" xml:space="preserve">
+      <trans-unit id="Autocomplete.customUrlAdded">
         <source>New Custom URL added.</source>
         <target>Új egyéni URL hozzáadva.</target>
         <note>Label for toast alerting a custom URL has been added</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultDescriptoin">
         <source>Enable to have %@ autocomplete over 450 popular URLs in the address bar.</source>
         <target>Engedélyezés, hogy a %@ 450 népszerű URL-t automatikusan kiegészítsen a címsávban.</target>
         <note>Description for enabling or disabling the default list. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultLabel">
         <source>Autocomplete</source>
         <target>Automatikus kiegészítés</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultTitle">
         <source>DEFAULT URL LIST</source>
         <target>ALAPÉRTELMEZETT URL LISTA</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.disabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.disabled">
         <source>Disabled</source>
         <target>Letiltva</target>
         <note>label describing URL Autocomplete as disabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.duplicateUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.duplicateUrl">
         <source>URL already exists</source>
         <target>Az URL már létezik</target>
         <note>Label for toast alerting that the custom URL being added is a duplicate</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.emptyState" xml:space="preserve">
+      <trans-unit id="Autocomplete.emptyState">
         <source>No Custom URLs to display</source>
         <target>Nincs megjelenítendő egyéni URL</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.enabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.enabled">
         <source>Enabled</source>
         <target>Engedélyezve</target>
         <note>label describing URL Autocomplete as enabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.manageSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.manageSites">
         <source>Manage Sites</source>
         <target>Oldalak kezelése</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySites" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySites">
         <source>My Sites</source>
         <target>Saját webhelyek</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySitesDesc" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySitesDesc">
         <source>Enable to have %@ autocomplete your favorite URLs.</source>
         <target>Engedélyezed, hogy a %@ kiegészítse a kedvenc URL-eit.</target>
         <note>Description for adding and managing custom autocomplete URLs. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.topSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.topSites">
         <source>Top Sites</source>
         <target>Népszerű oldalak</target>
         <note>Label for enabling or disabling top sites</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.newSession" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.newSession">
         <source>New Session</source>
         <target>Új munkamenetet</target>
         <note>Create a new session after failing a biometric check</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.reason" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.reason">
         <source>Unlock %@ when re-opening in order to prevent unauthorized access.</source>
         <target>A %@ feloldása, az alkalmazás újranyitásakor, hogy megakadályozza az illetéktelen hozzáférést.</target>
         <note>%@ is app name. Explanation for why the app needs access to biometric information. Prompt is only shown once when the user first tries to enable Face ID to open the app.</note>
       </trans-unit>
-      <trans-unit id="Browser.backLabel" xml:space="preserve">
+      <trans-unit id="Browser.backLabel">
         <source>Back</source>
         <target>Vissza</target>
         <note>Accessibility label for the back button</note>
       </trans-unit>
-      <trans-unit id="Browser.copyAddressLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyAddressLabel">
         <source>Copy Address</source>
         <target>Cím másolása</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.copyMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyMenuLabel">
         <source>Copy</source>
         <target>Másolás</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.customURLMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.customURLMenuLabel">
         <source>Add Custom URL</source>
         <target>Egyéni URL hozzáadása</target>
         <note>Custom URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.forwardLabel" xml:space="preserve">
+      <trans-unit id="Browser.forwardLabel">
         <source>Forward</source>
         <target>Előre</target>
         <note>Accessibility label for the forward button</note>
       </trans-unit>
-      <trans-unit id="Browser.reloadLabel" xml:space="preserve">
+      <trans-unit id="Browser.reloadLabel">
         <source>Reload</source>
         <target>Újratöltés</target>
         <note>Accessibility label for the reload button</note>
       </trans-unit>
-      <trans-unit id="Browser.settingsLabel" xml:space="preserve">
+      <trans-unit id="Browser.settingsLabel">
         <source>Settings</source>
         <target>Beállítások</target>
         <note>Accessibility label for the settings button</note>
       </trans-unit>
-      <trans-unit id="Browser.shareLabel" xml:space="preserve">
+      <trans-unit id="Browser.shareLabel">
         <source>Share</source>
         <target>Megosztás</target>
         <note>Accessibility label for the share button</note>
       </trans-unit>
-      <trans-unit id="Browser.stopLabel" xml:space="preserve">
+      <trans-unit id="Browser.stopLabel">
         <source>Stop</source>
         <target>Leállítás</target>
         <note>Accessibility label for the stop button</note>
       </trans-unit>
-      <trans-unit id="Cancel" xml:space="preserve">
+      <trans-unit id="Cancel">
         <source>Cancel</source>
         <target>Mégse</target>
         <note>Label on button to cancel edits</note>
       </trans-unit>
-      <trans-unit id="Done" xml:space="preserve">
+      <trans-unit id="Done">
         <source>Done</source>
         <target>Kész</target>
         <note>Label on button to complete edits</note>
       </trans-unit>
-      <trans-unit id="Edit" xml:space="preserve">
+      <trans-unit id="Edit">
         <source>Edit</source>
         <target>Szerkesztés</target>
         <note>Label on button to allow edits</note>
       </trans-unit>
-      <trans-unit id="Error.tryAgainButton" xml:space="preserve">
+      <trans-unit id="Error.tryAgainButton">
         <source>Try again</source>
         <target>Próbálja újra</target>
         <note>Button label to reload the error page</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.cancelTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.cancelTitle">
         <source>Cancel</source>
         <target>Mégse</target>
         <note>Button label used for cancelling to open another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.messageTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.messageTitle">
         <source>%@ wants to open another App</source>
         <target>A %@ egy másik appot akar megnyitni</target>
         <note>Dialog title used for opening an external app from Focus. The placeholder string is the app name of either Focus or Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.openTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.openTitle">
         <source>Open</source>
         <target>Megnyitás</target>
         <note>Button label for opening another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.callButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.callButton">
         <source>Call</source>
         <target>Hívás</target>
         <note>Button label in tel: dialog to call a phone number. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.cancelButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.cancelButton">
         <source>Cancel</source>
         <target>Mégse</target>
         <note>Button label in external link dialog to cancel the dialog. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.emailButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.emailButton">
         <source>Email</source>
         <target>E-mail</target>
         <note>Button label in mailto: dialog to send an email. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.messageTitleWithPlaceholder" xml:space="preserve">
+      <trans-unit id="ExternalLink.messageTitleWithPlaceholder">
         <source>You are now leaving %@.</source>
         <target>Most elhagyja a %@t.</target>
         <note>Dialog title used for Maps/App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreButton">
         <source>Open App Store</source>
         <target>App Store megnyitása</target>
         <note>Button label in App Store URL dialog to open the App Store. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreTitle" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreTitle">
         <source>%@ wants to open the App Store.</source>
         <target>A %@ meg akarja nyitni az App Storet.</target>
         <note>Dialog title used to open App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openMapsButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openMapsButton">
         <source>Open Maps</source>
         <target>Térképek megnyitása</target>
         <note>Button label in Maps URL dialog to open Maps. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="FindInPage.Done" xml:space="preserve">
+      <trans-unit id="FindInPage.Done">
         <source>Find in page done</source>
         <target>A keresés véget ért az oldalon</target>
         <note>Accessibility label for done button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.NextResult" xml:space="preserve">
+      <trans-unit id="FindInPage.NextResult">
         <source>Find next in page</source>
         <target>Következő keresése az oldalon</target>
         <note>Accessibility label for next result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.PreviousResult" xml:space="preserve">
+      <trans-unit id="FindInPage.PreviousResult">
         <source>Find previous in page</source>
         <target>Előző keresése az oldalon</target>
         <note>Accessibility label for previous result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FirstRun.lastSlide.buttonLabel" xml:space="preserve">
+      <trans-unit id="FirstRun.lastSlide.buttonLabel">
         <source>OK, Got It!</source>
         <target>Rendben, értem</target>
         <note>Label on button to dismiss first run UI</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelDescription" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelDescription">
         <source>Automatically block online trackers while you browse. Then tap to erase visited pages, searches, cookies and passwords from your device.</source>
         <target>Automatikusan blokkolja az online követőket böngészés közben. Aztán érintse meg a gombot a meglátogatott oldalak, keresések, sütik és jelszavak törléséhez az eszközéről.</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelTagline" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelTagline">
         <source>Browse like no one’s watching.</source>
         <target>Böngésszen úgy, mintha senki sem figyelné.</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="Focus.handoffSyncing" xml:space="preserve">
+      <trans-unit id="Focus.handoffSyncing">
         <source>Apple Handoff is syncing</source>
         <target>Az Apple Handoff szinkronizál</target>
         <note>Title for the loading screen when the handoff of clipboard delays Focus launch. “Handoff” should not be localized, see https://support.apple.com/HT204681</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel1" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel1">
         <source>Automatic private browsing.</source>
         <target>Automatikus privát böngészés.</target>
         <note>First label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel2" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel2">
         <source>Browse. Erase. Repeat.</source>
         <target>Böngészés. Törlés. Ismétlés.</target>
         <note>Second label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Menu.Close" xml:space="preserve">
+      <trans-unit id="Menu.Close">
         <source>Close</source>
         <target>Bezárás</target>
         <note>Button label used to close a menu that displays as a popup.</note>
       </trans-unit>
-      <trans-unit id="Open.Cancel" xml:space="preserve">
+      <trans-unit id="Open.Cancel">
         <source>Cancel</source>
         <target>Mégse</target>
         <note>Label in share alert to cancel the alert</note>
       </trans-unit>
-      <trans-unit id="Open.Firefox" xml:space="preserve">
+      <trans-unit id="Open.Firefox">
         <source>Firefox (Private Browsing)</source>
         <target>Firefox (Privát böngészés)</target>
         <note>Label in share alert to open the URL in Firefox</note>
       </trans-unit>
-      <trans-unit id="Open.More" xml:space="preserve">
+      <trans-unit id="Open.More">
         <source>More</source>
         <target>Több</target>
         <note>Label in share alert to open the full system share menu</note>
       </trans-unit>
-      <trans-unit id="Open.Safari" xml:space="preserve">
+      <trans-unit id="Open.Safari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Label in share alert to open the URL in Safari</note>
       </trans-unit>
-      <trans-unit id="Request Desktop Site" xml:space="preserve">
+      <trans-unit id="Request Desktop Site">
         <source>Request Desktop Site</source>
         <target>Asztali oldal kérése</target>
         <note>Label for button that requests the desktop version of the currently loaded website.</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsContentBlockers" xml:space="preserve">
+      <trans-unit id="Safari.instructionsContentBlockers">
         <source>Tap Safari, then select Content Blockers</source>
         <target>Érintse meg a Safarit, majd válassza a Tartalomblokkolókat</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsEnable" xml:space="preserve">
+      <trans-unit id="Safari.instructionsEnable">
         <source>Enable %@</source>
         <target>%@ engedélyezése</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsNotEnabled" xml:space="preserve">
+      <trans-unit id="Safari.instructionsNotEnabled">
         <source>%@ is not enabled.</source>
         <target>A %@ nincs engedélyezve.</target>
         <note>Error label when the blocker is not enabled, shown in the intro and main app when disabled</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsOpen" xml:space="preserve">
+      <trans-unit id="Safari.instructionsOpen">
         <source>Open Settings App</source>
         <target>Beállítások app megnyitása</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Save" xml:space="preserve">
+      <trans-unit id="Save">
         <source>Save</source>
         <target>Mentés</target>
         <note>Save button label</note>
       </trans-unit>
-      <trans-unit id="SearchEngine.addEngineError" xml:space="preserve">
+      <trans-unit id="SearchEngine.addEngineError">
         <source>That didn't work. Try replacing the search term with this: %s.</source>
         <target>Ez nem működött. Próbálja lecserélni a keresési kifejezést erre: %s.</target>
         <note>Label for error state when entering an invalid search engine URL. %s is a search term in a URL.</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptDisable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptDisable">
         <source>No</source>
         <target>Nem</target>
         <note>Label for disable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptEnable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptEnable">
         <source>Yes</source>
         <target>Igen</target>
         <note>Label for enable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptMessage" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptMessage">
         <source>To get suggestions, %@ needs to send what you type in the address bar to the search engine.</source>
         <target>A javaslatok kéréséhez a %@nak el kell küldenie a címsorba írt üzenetet a keresőszolgáltatásnak.</target>
         <note>%@ is the name of the app (Focus / Klar). Label for search suggestions prompt message</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptTitle" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptTitle">
         <source>Show Search Suggestions?</source>
         <target>Jelenítsen-e meg keresési javaslatokat?</target>
         <note>Title for search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButton" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButton">
         <source>Add Another Search Engine</source>
         <target>További keresőszolgáltatás felvétele</target>
         <note>Text for button to add another search engine in settings</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus">
         <source>+ Add Another Search Engine</source>
         <target>+ További keresőszolgáltatás felvétele</target>
         <note>Text for button to add another search engine in settings with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineTitle" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineTitle">
         <source>Add Search Engine</source>
         <target>Keresőszolgáltatás hozzáadása</target>
         <note>Title on add search engine settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.InstalledSearchEngines" xml:space="preserve">
+      <trans-unit id="Settings.Search.InstalledSearchEngines">
         <source>INSTALLED SEARCH ENGINES</source>
         <target>TELEPÍTETT KERESŐSZOLGÁLTATÁSOK</target>
         <note>Header for rows of installed search engines</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NameToDisplay" xml:space="preserve">
+      <trans-unit id="Settings.Search.NameToDisplay">
         <source>Name to display</source>
         <target>Megjelenítendő név</target>
         <note>Label for input field for the name of the search engine to be added</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NewSearchEngineAdded" xml:space="preserve">
+      <trans-unit id="Settings.Search.NewSearchEngineAdded">
         <source>New Search Engine Added.</source>
         <target>Új keresőszolgáltatás hozzáadása.</target>
         <note>Toast displayed after adding a search engine</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.RestoreEngine" xml:space="preserve">
+      <trans-unit id="Settings.Search.RestoreEngine">
         <source>Restore Default Search Engines</source>
         <target>Alapértelmezett keresőszolgáltatások visszaállítása</target>
         <note>Label for button to bring deleted default engines back</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchEngineName" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchEngineName">
         <source>Search engine name</source>
         <target>Keresőszolgáltatás neve</target>
         <note>Placeholder text for input of new search engine name</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplate" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplate">
         <source>Search string to use</source>
         <target>Használandó keresőkifejezés</target>
         <note>Label for input of search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplatePlaceholder" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplatePlaceholder">
         <source>Paste or enter search string. If necessary, replace search term with: %s.</source>
         <target>Másoljon vagy írjon be keresőkifejezést. Ha szükséges, helyettesítse a keresőkifejezést ezzel: %s.</target>
         <note>Placeholder text for input of new search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.autocompleteSection" xml:space="preserve">
+      <trans-unit id="Settings.autocompleteSection">
         <source>URL Autocomplete</source>
         <target>Automatikus URL kiegészítés</target>
         <note>Title for the URL Autocomplete row</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherMessage" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherMessage">
         <source>Blocking other content trackers may break some videos and web pages.</source>
         <target>A többi tartalomkövető blokkolása eltörhet bizonyos videókat és weblapokat.</target>
         <note>Alert message shown when toggling the Content blocker</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherNo2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherNo2">
         <source>Cancel</source>
         <target>Mégse</target>
         <note>Button label for declining Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherYes2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherYes2">
         <source>Block Content Trackers</source>
         <target>Tartalomkövetők blokkolása</target>
         <note>Button label for accepting Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSearchSuggestion" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSearchSuggestion">
         <source>%@ will send what you type in the address bar to your search engine.</source>
         <target>A %@ elküldi a címsávba írt szöveget a keresőszolgáltatásának.</target>
         <note>Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSendUsageData">
         <source>Mozilla strives to collect only what we need to provide and improve %@ for everyone.</source>
         <target>A Mozilla arra törekszik, hogy csak azt gyűjtse, ami a %@ fejlesztéséhez és támogatásához szükséges.</target>
         <note>Description associated to the Send Usage Data toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.learnMore" xml:space="preserve">
+      <trans-unit id="Settings.learnMore">
         <source>Learn more.</source>
         <target>Tudjon meg többet.</target>
         <note>Subtitle for Send Anonymous Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.rate" xml:space="preserve">
+      <trans-unit id="Settings.rate">
         <source>Rate %@</source>
         <target>A %@ értékelése</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, allows the user to leave a review for the app on the app store.</note>
       </trans-unit>
-      <trans-unit id="Settings.safariTitle" xml:space="preserve">
+      <trans-unit id="Settings.safariTitle">
         <source>SAFARI INTEGRATION</source>
         <target>SAFARI INTEGRÁCIÓ</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.screenTitle" xml:space="preserve">
+      <trans-unit id="Settings.screenTitle">
         <source>Settings</source>
         <target>Beállítások</target>
         <note>Title for settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchLabel" xml:space="preserve">
+      <trans-unit id="Settings.searchLabel">
         <source>Search Engine</source>
         <target>Keresőszolgáltatás</target>
         <note>Label for the search engine in the search screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchSuggestions" xml:space="preserve">
+      <trans-unit id="Settings.searchSuggestions">
         <source>Get Search Suggestions</source>
         <target>Keresési javaslatok kérése</target>
         <note>Label for the Search Suggestions toggle row</note>
       </trans-unit>
-      <trans-unit id="Settings.searchTitle2" xml:space="preserve">
+      <trans-unit id="Settings.searchTitle2">
         <source>SEARCH</source>
         <target>KERESÉS</target>
         <note>Title for the search selection screen</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionIntegration" xml:space="preserve">
+      <trans-unit id="Settings.sectionIntegration">
         <source>INTEGRATION</source>
         <target>INTEGRÁCIÓ</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionMozilla" xml:space="preserve">
+      <trans-unit id="Settings.sectionMozilla">
         <source>MOZILLA</source>
         <target>MOZILLA</target>
         <note>Section label for Mozilla toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPerformance" xml:space="preserve">
+      <trans-unit id="Settings.sectionPerformance">
         <source>PERFORMANCE</source>
         <target>TELJESÍTMÉNY</target>
         <note>Section label for performance toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPrivacy" xml:space="preserve">
+      <trans-unit id="Settings.sectionPrivacy">
         <source>PRIVACY</source>
         <target>ADATVÉDELEM</target>
         <note>Section label for privacy toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionSecurity" xml:space="preserve">
+      <trans-unit id="Settings.sectionSecurity">
         <source>SECURITY</source>
         <target>BIZTONSÁG</target>
         <note>Header label for security toggles displayed in the settings menu</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAds2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAds2">
         <source>Advertising</source>
         <target>Hirdetések</target>
         <note>Label for the checkbox to toggle Advertising trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAnalytics2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAnalytics2">
         <source>Analytics</source>
         <target>Analitika</target>
         <note>Label for the checkbox to toggle Analytics trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockFonts" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockFonts">
         <source>Block web fonts</source>
         <target>Webes betűkészletek blokkolása</target>
         <note>Label for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockOther2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockOther2">
         <source>Content</source>
         <target>Tartalom</target>
         <note>Label for the checkbox to toggle Other trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockSocial2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockSocial2">
         <source>Social</source>
         <target>Közösségi média</target>
         <note>Label for the checkbox to toggle Social trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceID" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceID">
         <source>Use Face ID to unlock app</source>
         <target>Face ID használata az alkalmazás kinyitásához</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceIDDescription">
         <source>Face ID can unlock %@ if a URL is already open in the app</source>
         <target>A Face ID feloldhatja a %@t, ha az URL már meg van nyitva az alkalmazásban</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Face ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleHomeScreenTips" xml:space="preserve">
+      <trans-unit id="Settings.toggleHomeScreenTips">
         <source>Show home screen tips</source>
         <target>Tippek megjelenítése a kezdőképernyőn</target>
         <note>Show home screen tips toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleOtherSubtitle" xml:space="preserve">
+      <trans-unit id="Settings.toggleOtherSubtitle">
         <source>May break some videos and Web pages</source>
         <target>Néhány videó és weblap eltörhet</target>
         <note>Label subtitle for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSafari" xml:space="preserve">
+      <trans-unit id="Settings.toggleSafari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Safari toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.toggleSendUsageData">
         <source>Send usage data</source>
         <target>Használati adatok elküldése</target>
         <note>Label for Send Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchID" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchID">
         <source>Use Touch ID to unlock app</source>
         <target>Touch ID használata az alkalmazás kinyitásához</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchIDDescription">
         <source>Touch ID can unlock %@ if a URL is already open in the app</source>
         <target>A Touch ID feloldhatja a %@t, ha az URL már meg van nyitva az alkalmazásban</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Touch ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOff" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOff">
         <source>Off</source>
         <target>Ki</target>
         <note>Status off for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOn" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOn">
         <source>On</source>
         <target>Be</target>
         <note>Status on for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.whatsNewTitle" xml:space="preserve">
+      <trans-unit id="Settings.whatsNewTitle">
         <source>What’s New</source>
         <target>Újdonságok</target>
         <note>Title for What's new screen</note>
       </trans-unit>
-      <trans-unit id="Settinsg.siriShortcutsTitle" xml:space="preserve">
+      <trans-unit id="Settinsg.siriShortcutsTitle">
         <source>SIRI SHORTCUTS</source>
         <target>SIRI GYORS PARANCSOK</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.FindInPage" xml:space="preserve">
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Keresés az oldalon</target>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.GetFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.GetFirefox">
         <source>Get the Firefox App</source>
         <target>App Store: Firefox</target>
         <note>Text for the share menu option when a user wants to open a page in Firefox but doesn’t have it installed. This string will not wrap in the interface. Instead, it will truncate. To prevent this, please keep the localized string to 18 or fewer characters. If your string runs longer than 18 characters, you can use 'Get Firefox' as the basis for your string. However, if at all possible, we’d like to signal to the user that they will be going to the App Store and installing the application from there. That is why we are using Get and App in the en-US string.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.PageActions" xml:space="preserve">
+      <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <target>Lapműveletek</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestDesktop" xml:space="preserve">
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
         <target>Asztali oldal kérése</target>
         <note>Text for the share menu option when a user wants to reload the site as a desktop</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestMobile" xml:space="preserve">
+      <trans-unit id="ShareMenu.RequestMobile">
         <source>Request Mobile Site</source>
         <target>Mobil oldal kérése</target>
         <note>Text for the share menu option when a user wants to reload the site as a mobile device</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenChrome" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenChrome">
         <source>Open in Chrome</source>
         <target>Megnyitás a Chrome-ban</target>
         <note>Text for the share menu option when a user wants to open the current website in the Chrome app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenFirefox">
         <source>Open in Firefox</source>
         <target>Megnyitás a Firefoxban</target>
         <note>Text for the share menu option when a user wants to open the current website in the Firefox app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenSafari" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenSafari">
         <source>Open in Safari</source>
         <target>Megnyitás a Safariban</target>
         <note>Text for the share menu option when a user wants to open the current website in the Safari app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.SharePage" xml:space="preserve">
+      <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <target>Lap megosztása…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
       </trans-unit>
-      <trans-unit id="Siri.add" xml:space="preserve">
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
+      </trans-unit>
+      <trans-unit id="Siri.add">
         <source>Add</source>
         <target>Hozzáadás</target>
         <note>Button to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.addTo" xml:space="preserve">
+      <trans-unit id="Siri.addTo">
         <source>Add to Siri</source>
         <target>Hozzáadása a Sirihez</target>
         <note>Button to add a specified shortcut option to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.editOpenUrl" xml:space="preserve">
+      <trans-unit id="Siri.editOpenUrl">
         <source>Re-Record or Delete Shortcut</source>
         <target>Gyors parancs újrarögzítése vagy törlése</target>
         <note>Label for button to edit the Siri phrase or delete the Siri functionality.</note>
       </trans-unit>
-      <trans-unit id="Siri.erase" xml:space="preserve">
+      <trans-unit id="Siri.erase">
         <source>Erase</source>
         <target>Törlés</target>
         <note>Title of option in settings to set up Siri to erase</note>
       </trans-unit>
-      <trans-unit id="Siri.eraseAndOpen" xml:space="preserve">
+      <trans-unit id="Siri.eraseAndOpen">
         <source>Erase &amp; Open</source>
         <target>Törlés és megnyitás</target>
         <note>Title of option in settings to set up Siri to erase and then open the app.</note>
       </trans-unit>
-      <trans-unit id="Siri.favoriteUrl" xml:space="preserve">
+      <trans-unit id="Siri.favoriteUrl">
         <source>Open Favorite Site</source>
         <target>Kedvenc oldal megnyitása</target>
         <note>Title for screen to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.openURL" xml:space="preserve">
+      <trans-unit id="Siri.openURL">
         <source>Open Favorite Site</source>
         <target>Kedvenc oldal megnyitása</target>
         <note>Title of option in settings to set up Siri to open a specified URL in Focus/Klar.</note>
       </trans-unit>
-      <trans-unit id="Siri.urlToOpen" xml:space="preserve">
+      <trans-unit id="Siri.urlToOpen">
         <source>URL to open</source>
         <target>Megnyitandó URL</target>
         <note>Label for input to set a favorite URL to be opened by Siri.</note>
       </trans-unit>
-      <trans-unit id="URL.addToAutocompleteLabel" xml:space="preserve">
+      <trans-unit id="URL.addToAutocompleteLabel">
         <source>Add link to autocomplete</source>
         <target>Hivatkozás hozzáadása az automatikus kiegészítéshez</target>
         <note>Label displayed for button used as a shortcut to add a link to the list of URLs to autocomplete.</note>
       </trans-unit>
-      <trans-unit id="URL.cancelLabel" xml:space="preserve">
+      <trans-unit id="URL.cancelLabel">
         <source>Cancel</source>
         <target>Mégse</target>
         <note>Label for cancel button shown when entering a URL or search</note>
       </trans-unit>
-      <trans-unit id="URL.contextMenu" xml:space="preserve">
+      <trans-unit id="URL.contextMenu">
         <source>Paste &amp; Go</source>
         <target>Beillesztés és ugrás</target>
         <note>Text for the URL context menu when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.eraseButtonLabel" xml:space="preserve">
+      <trans-unit id="URL.eraseButtonLabel">
         <source>ERASE</source>
         <target>TÖRLÉS</target>
         <note>Erase button in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.eraseMessageLabel2" xml:space="preserve">
+      <trans-unit id="URL.eraseMessageLabel2">
         <source>Browsing history cleared</source>
         <target>Böngészési előzmények törölve</target>
         <note>Message shown after pressing the Erase button</note>
       </trans-unit>
-      <trans-unit id="URL.findOnPageLabel" xml:space="preserve">
+      <trans-unit id="URL.findOnPageLabel">
         <source>Find in page: %@</source>
         <target>Keresés az oldalon: %@</target>
         <note>Label displayed for find in page button when typing in the URL Bar. %@ is any text the user has typed into the URL bar that they want to find on the current page.</note>
       </trans-unit>
-      <trans-unit id="URL.paste" xml:space="preserve">
+      <trans-unit id="URL.paste">
         <source>Paste</source>
         <target>Beillesztés</target>
         <note>Text for a menu displayed from the bottom of the screen when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.placeholderText" xml:space="preserve">
+      <trans-unit id="URL.placeholderText">
         <source>Search or enter address</source>
         <target>Keressen, vagy adjon meg címet</target>
         <note>Placeholder text shown in the URL bar before the user navigates to a page</note>
       </trans-unit>
-      <trans-unit id="URL.searchLabel" xml:space="preserve">
+      <trans-unit id="URL.searchLabel">
         <source>Search for %@</source>
         <target>Keresés erre: %@</target>
         <note>Label displayed for search button when typing in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="URL.trackersBlockedLabel">
         <source>Trackers blocked</source>
         <target>Blokkolt követők</target>
         <note>Text for the URL bar showing the number of trackers blocked on a webpage.</note>
       </trans-unit>
-      <trans-unit id="actionSheet.openIn" xml:space="preserve">
+      <trans-unit id="actionSheet.openIn">
         <source>Open in %@</source>
         <target>Megnyitás ezzel: %@</target>
         <note>Title for action sheet item to open the current page in another application. Placeholder is the name of the application to open the current page.</note>
       </trans-unit>
-      <trans-unit id="browser.copyAddressToast" xml:space="preserve">
+      <trans-unit id="browser.copyAddressToast">
         <source>URL Copied To Clipboard</source>
         <target>URL a vágólapra másolva</target>
         <note>Toast displayed after a URL has been copied to the clipboard</note>
       </trans-unit>
-      <trans-unit id="browserShortcutDescription.selectLocationBar" xml:space="preserve">
+      <trans-unit id="browserShortcutDescription.selectLocationBar">
         <source>Select Location Bar</source>
         <target>Címsáv kiválasztása</target>
         <note>Label to display in the Discoverability overlay for keyboard shortcuts</note>
       </trans-unit>
-      <trans-unit id="contextMenu.clipboardLink" xml:space="preserve">
+      <trans-unit id="contextMenu.clipboardLink">
         <source>Link you copied: %@</source>
         <target>A másolt hivatkozás: %@</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.copyImageTitle">
         <source>Copy Image</source>
         <target>Kép másolása</target>
         <note>Text for the context menu when a user wants to copy an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyLink" xml:space="preserve">
+      <trans-unit id="contextMenu.copyLink">
         <source>Copy Link</source>
         <target>Hivatkozás másolása</target>
         <note>Text for the context menu when a user wants to copy a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.linkCopied" xml:space="preserve">
+      <trans-unit id="contextMenu.linkCopied">
         <source>Link you copied: </source>
         <target>A másolt hivatkozás:</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.saveImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.saveImageTitle">
         <source>Save Image</source>
         <target>Kép mentése</target>
         <note>Text for the context menu when a user wants to save an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.shareLinkTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.shareLinkTitle">
         <source>Share Link</source>
         <target>Hivatkozás megosztása</target>
         <note>Text for the context menu when a user wants to share a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="externalAppLinkWithAppName.messageTitle" xml:space="preserve">
+      <trans-unit id="externalAppLinkWithAppName.messageTitle">
         <source>%1$@ wants to open %2$@</source>
         <target>A %1$@ meg akarja nyitni a(z) %2$@ appot</target>
         <note>Dialog title used for opening an external app from Focus. First placeholder string is the app name of either Focus or Klar and the second placeholder string specifies the app it wants to open.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.description" xml:space="preserve">
+      <trans-unit id="photosPermission.description">
         <source>This lets you save images to your Camera Roll</source>
         <target>Ezzel elmentheti a képet a Filmtekercsébe</target>
         <note>Description for dialog used for requesting a user to enable access to Photos.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.openSettings" xml:space="preserve">
+      <trans-unit id="photosPermission.openSettings">
         <source>Open Settings</source>
         <target>Beállítások megnyitása</target>
         <note>Title for button that takes the user to system settings</note>
       </trans-unit>
-      <trans-unit id="photosPermission.title" xml:space="preserve">
+      <trans-unit id="photosPermission.title">
         <source>“%@” Would Like to Access Your Photos</source>
         <target>A „%@” szeretne hozzáférni a fényképeihez</target>
         <note>Dialog title used for requesting a user to enable access to Photos. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="settings.Search.SearchTemplateExample" xml:space="preserve">
+      <trans-unit id="settings.Search.SearchTemplateExample">
         <source>Example: searchengineexample.com/search/?q=%s</source>
         <target>Példa: searchengineexample.com/search/?q=%s</target>
         <note>Text displayed as an example of the template to add a search engine.</note>
       </trans-unit>
-      <trans-unit id="share" xml:space="preserve">
+      <trans-unit id="share">
         <source>Share</source>
         <target>Megosztás</target>
         <note>Text for a share button</note>
       </trans-unit>
-      <trans-unit id="shareMenu.copyAddress" xml:space="preserve">
+      <trans-unit id="shareMenu.copyAddress">
         <source>Copy Address</source>
         <target>Cím másolása</target>
         <note>Text for the share menu when a user wants to copy a URL.</note>
       </trans-unit>
-      <trans-unit id="touchId.reason" xml:space="preserve">
+      <trans-unit id="touchId.reason">
         <source>Use Touch ID to return to %@</source>
         <target>Használja a Touch ID-t a %@ böngészőbe visszatéréshez</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.adTrackersLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.adTrackersLabel">
         <source>Ad trackers</source>
         <target>Hirdetéskövetők</target>
         <note>Label for ad trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.analyticTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.analyticTrackerLabel">
         <source>Analytic trackers</source>
         <target>Analitikai követők</target>
         <note>label for analytic trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.contentTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>
         <target>Tartalomkövetők</target>
         <note>label for content trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.disabledLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.disabledLabel">
         <source>Tracking Protection off</source>
         <target>Követés elleni védelem kikapcsolva</target>
         <note>text showing the tracking protection is disabled.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.label" xml:space="preserve">
+      <trans-unit id="trackingProtection.label">
         <source>Tracking Protection</source>
         <target>Követés elleni védelem</target>
         <note>Title for the tracking settings page to change what trackers are blocked.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.labelDescription" xml:space="preserve">
+      <trans-unit id="trackingProtection.labelDescription">
         <source>Turning this off may fix some site problems</source>
         <target>Ennek a kikapcsolása megoldhatja egyes webhelyek problémáit</target>
         <note>Description/subtitle for the tracking protection label.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.learnMore" xml:space="preserve">
+      <trans-unit id="trackingProtection.learnMore">
         <source>Learn More</source>
         <target>További tudnivalók</target>
         <note>Text for the button to learn more about Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.moreSettings" xml:space="preserve">
+      <trans-unit id="trackingProtection.moreSettings">
         <source>More Settings</source>
         <target>További beállítások</target>
         <note>Text for the button that closes the Shield Data and opens the regular Settings screen.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.socialTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.socialTrackerLabel">
         <source>Social trackers</source>
         <target>Közösségi követők</target>
         <note>label for social trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOff" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOff">
         <source>Protections are OFF for this session</source>
         <target>A védelem KI van kapcsolva ebben a munkamenetben</target>
         <note>Text for the status off from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOn" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOn">
         <source>Protections are ON for this session</source>
         <target>A védelem BE van kapcsolva ebben a munkamenetben</target>
         <note>Text for the status on from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleDescription1" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleDescription1">
         <source>Disable until you close %@ or tap ERASE.</source>
         <target>Letiltás a %@ bezárásáig, vagy megérinti a TÖRLÉS gombot.</target>
         <note>Description for the tracking protection toggle. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleLabel2">
         <source>Enhanced Tracking Protection</source>
         <target>Fokozott követés elleni védelem</target>
         <note>Text for the toggle that enables/disables tracking protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackerDescriptionLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackerDescriptionLabel2">
         <source>Keep your data to yourself. %@ protects you from many of the most common trackers that follow what you do online.</source>
         <target>Tartsa meg az adatait. A %@ megvédi a leggyakoribb nyomkövetőktől, amelyek követik az online tevékenységét.</target>
         <note>General description of tracking protection settings, which is displayed underneath the trackers preferences in Settings. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersBlockedLabel">
         <source>Trackers blocked since %@</source>
         <target>Blokkolt nyomkövetők %@ óta</target>
         <note>Text for tracking protection screen showing the number of trackers blocked since the app install. The placeholder is replaced with the install date of the application.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersHeader" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersHeader">
         <source>Trackers and scripts to block</source>
         <target>Blokkolandó követők és parancsfájlok</target>
         <note>Text for the header of trackers section from Tracking Protection.</note>
@@ -1078,7 +1097,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="SettingsBundle.Licenses" xml:space="preserve">
+      <trans-unit id="SettingsBundle.Licenses">
         <source>Licenses</source>
         <target>Licencek</target>
         <note>The title of the Licenses setting in the settings that Focus shows in the global iOS Settings app.</note>
@@ -1086,3 +1105,4 @@
     </body>
   </file>
 </xliff>
+

--- a/hy-AM/focus-ios.xliff
+++ b/hy-AM/focus-ios.xliff
@@ -723,6 +723,10 @@
         <source>SIRI SHORTCUTS</source>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
@@ -735,6 +739,10 @@
       <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -759,6 +767,10 @@
       <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -927,6 +939,14 @@
         <source>Analytic trackers</source>
         <target>Վերլուծական հետագծումներ</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/ia/focus-ios.xliff
+++ b/ia/focus-ios.xliff
@@ -1,36 +1,35 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Blockzilla/en.lproj/InfoPlist.strings" source-language="en" target-language="ia" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="NSCameraUsageDescription" xml:space="preserve">
+      <trans-unit id="NSCameraUsageDescription">
         <source>This lets you take and upload photos.</source>
         <target>Isto te permitte de prender e inviar photos.</target>
         <note>Privacy - Camera Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSFaceIDUsageDescription" xml:space="preserve">
+      <trans-unit id="NSFaceIDUsageDescription">
         <source>This lets you unlock the app.</source>
         <target>Isto te lassa disblocar le application.</target>
         <note>Privacy - Face ID Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSLocationWhenInUseUsageDescription" xml:space="preserve">
+      <trans-unit id="NSLocationWhenInUseUsageDescription">
         <source>Websites you visit may request your location.</source>
         <target>Le sitos web visitate pote requirer tu geolocalisation.</target>
         <note>Privacy - Location When In Use Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSMicrophoneUsageDescription" xml:space="preserve">
+      <trans-unit id="NSMicrophoneUsageDescription">
         <source>This lets you take and upload videos.</source>
         <target>Isto te permitte de prender e inviar videos.</target>
         <note>Privacy - Microphone Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSPhotoLibraryAddUsageDescription" xml:space="preserve">
+      <trans-unit id="NSPhotoLibraryAddUsageDescription">
         <source>This lets you save and upload photos.</source>
         <target>Isto te permitte de salvar e inviar photos.</target>
         <note>Privacy - Photo Library Additions Usage Description</note>
       </trans-unit>
-      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen" xml:space="preserve">
+      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen">
         <source>Erase and Open</source>
         <target>Eliminar e aperir</target>
         <note>This is the menu item that appears when you long press the Focus icon on the phone home screen.</note>
@@ -42,7 +41,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intents.Erase.Title" xml:space="preserve">
+      <trans-unit id="Intents.Erase.Title">
         <source>Erase</source>
         <target>Eliminar</target>
         <note>Title of the Erase intent.</note>
@@ -54,42 +53,42 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intro.Slides.History.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Description">
         <source>Clear your entire browsing session history, passwords, cookies anytime with a single tap.</source>
         <target>Vacua tu integre chronologia del session de navigation, contrasignos, cookies, quando tu vole con un singule tocco.</target>
         <note>Description for the 'History' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.History.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Title">
         <source>Your history is history</source>
         <target>Tu chronologia es historia</target>
         <note>Title for the third  panel 'History' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Next.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Next.Button">
         <source>Next</source>
         <target>Sequente</target>
         <note>Button to go to the next card in Focus onboarding.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Description">
         <source>Searching for something different? Choose a different search engine.</source>
         <target>Cerca tu qualcosa differente? Elige un altere motor de recerca.</target>
         <note>Description for the 'Favorite Search Engine' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Title">
         <source>Your search, your way</source>
         <target>Le recerca a tu gusto</target>
         <note>Title for the second  panel 'Search' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Skip.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Skip.Button">
         <source>Skip</source>
         <target>Saltar</target>
         <note>Button to skip onboarding in Focus</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Description">
         <source>Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times.</source>
         <target>Porta le navigation private al nivello superior. Bloca publicitates e altere contentos que pote traciar te per le sitos e relentar le tempore de carga del paginas.</target>
         <note>Description for the 'Welcome' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Title">
         <source>Power up your privacy</source>
         <target>Reinfortia tu confidentialitate</target>
         <note>Title for the first panel 'Welcome' in the First Run tour.</note>
@@ -101,973 +100,993 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="About.learnMoreButton" xml:space="preserve">
+      <trans-unit id="About.learnMoreButton">
         <source>Learn more</source>
         <target>Saper plus</target>
         <note>Button on About screen</note>
       </trans-unit>
-      <trans-unit id="About.missionLabel" xml:space="preserve">
+      <trans-unit id="About.missionLabel">
         <source>%@ is produced by Mozilla. Our mission is to foster a healthy, open Internet.</source>
         <target>%@ es producite per Mozilla. Nostre mission es promover un internet salubre e libere.</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet1" xml:space="preserve">
+      <trans-unit id="About.privateBullet1">
         <source>Search and browse right in the app</source>
         <target>Recerca e naviga justo intra le application</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet2" xml:space="preserve">
+      <trans-unit id="About.privateBullet2">
         <source>Block trackers (or update settings to allow trackers)</source>
         <target>Bloca le traciatores (o modifica le parametros pro los autorisar)</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet3" xml:space="preserve">
+      <trans-unit id="About.privateBullet3">
         <source>Erase to delete cookies as well as search and browsing history</source>
         <target>Cancella pro eliminar le cookies e le chronologias de recerca e de navigation</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBulletHeader" xml:space="preserve">
+      <trans-unit id="About.privateBulletHeader">
         <source>Use it as a private browser:</source>
         <target>Usa lo como navigator private:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowHelp" xml:space="preserve">
+      <trans-unit id="About.rowHelp">
         <source>Help</source>
         <target>Adjuta</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowPrivacy" xml:space="preserve">
+      <trans-unit id="About.rowPrivacy">
         <source>Privacy Notice</source>
         <target>Notification de confidentialitate</target>
         <note>Link to Privacy Notice in the About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowRights" xml:space="preserve">
+      <trans-unit id="About.rowRights">
         <source>Your Rights</source>
         <target>Tu derectos</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet1" xml:space="preserve">
+      <trans-unit id="About.safariBullet1">
         <source>Block trackers for improved privacy</source>
         <target>Bloca le traciatores pro un melior confidentialitate</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet2" xml:space="preserve">
+      <trans-unit id="About.safariBullet2">
         <source>Block web fonts to reduce page size</source>
         <target>Bloca le discargamento de characteres web pro reducer le dimension del pagina</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBulletHeader" xml:space="preserve">
+      <trans-unit id="About.safariBulletHeader">
         <source>Use it as a Safari extension:</source>
         <target>Usa lo como extension de Safari:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.title" xml:space="preserve">
+      <trans-unit id="About.title">
         <source>About %@</source>
         <target>A proposito de %@</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, takes the user to a page with information about the product. Also displayed as a header for the About page.</note>
       </trans-unit>
-      <trans-unit id="About.topLabel" xml:space="preserve">
+      <trans-unit id="About.topLabel">
         <source>%@ puts you in control.</source>
         <target>%@ te pone al commando.</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Dismiss" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Dismiss">
         <source>Ok</source>
         <target>Ok</target>
         <note>Button to dismiss the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Message" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Message">
         <source>An error occured while adding the pass to Wallet. Please try again later.</source>
         <target>Un error ha occurrite durante le addition del billet a Wallet. Per favor retenta plus tarde.</target>
         <note>Message of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Title" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Title">
         <source>Failed to Add Pass</source>
         <target>Error al adder le billet</target>
         <note>Title of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="Authentication.reason" xml:space="preserve">
+      <trans-unit id="Authentication.reason">
         <source>Authenticate to return to %@</source>
         <target>Authenticar se pro retornar a %@</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID, Face ID, or passcode to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrl">
         <source>Add Custom URL</source>
         <target>Adder URL personalisate</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlError" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlError">
         <source>Double-check the URL you entered.</source>
         <target>Clicca duple le URL que tu insereva.</target>
         <note>Label for error state when entering an invalid URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlExample" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlExample">
         <source>Example: example.com</source>
         <target>Exemplo: example.com</target>
         <note>A label displaying an example URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlLabel">
         <source>URL to add</source>
         <target>URL a adder</target>
         <note>Label for the input to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlPlaceholder" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlPlaceholder">
         <source>Paste or enter URL</source>
         <target>Colla o insere le URL</target>
         <note>Placeholder for the input field to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlWithPlus" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlWithPlus">
         <source>+ Add Custom URL</source>
         <target>+ Adder URL personalisate</target>
         <note>Label for button to add a custom URL with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.customDescriptoin">
         <source>Add and manage custom autocomplete URLs.</source>
         <target>Adde e gere le complementamento personalisate del URLs.</target>
         <note>Description for adding and managing custom autocomplete URLs</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.customLabel">
         <source>Custom URLs</source>
         <target>URLs personalisate</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.customTitle">
         <source>CUSTOM URL LIST</source>
         <target>LISTA del URLs PERSONALISATE</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customUrlAdded" xml:space="preserve">
+      <trans-unit id="Autocomplete.customUrlAdded">
         <source>New Custom URL added.</source>
         <target>Nove URL personalisate addite.</target>
         <note>Label for toast alerting a custom URL has been added</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultDescriptoin">
         <source>Enable to have %@ autocomplete over 450 popular URLs in the address bar.</source>
         <target>Activa pro consentir a %@ de auto-completar plus de 450 URLs popular in le barra de adresses.</target>
         <note>Description for enabling or disabling the default list. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultLabel">
         <source>Autocomplete</source>
         <target>Auto-completar</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultTitle">
         <source>DEFAULT URL LIST</source>
         <target>LISTA del URLs PREDEFINITE</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.disabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.disabled">
         <source>Disabled</source>
         <target>Disactivate</target>
         <note>label describing URL Autocomplete as disabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.duplicateUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.duplicateUrl">
         <source>URL already exists</source>
         <target>Le URL existe ja</target>
         <note>Label for toast alerting that the custom URL being added is a duplicate</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.emptyState" xml:space="preserve">
+      <trans-unit id="Autocomplete.emptyState">
         <source>No Custom URLs to display</source>
         <target>Nulle URLs personalisate a monstrar</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.enabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.enabled">
         <source>Enabled</source>
         <target>Activate</target>
         <note>label describing URL Autocomplete as enabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.manageSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.manageSites">
         <source>Manage Sites</source>
         <target>Gerer le sitos</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySites" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySites">
         <source>My Sites</source>
         <target>Mi sitos</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySitesDesc" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySitesDesc">
         <source>Enable to have %@ autocomplete your favorite URLs.</source>
         <target>Activar pro que %@ completa automaticamente te URLs favorite.</target>
         <note>Description for adding and managing custom autocomplete URLs. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.topSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.topSites">
         <source>Top Sites</source>
         <target>Sitos popular</target>
         <note>Label for enabling or disabling top sites</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.newSession" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.newSession">
         <source>New Session</source>
         <target>Nove session</target>
         <note>Create a new session after failing a biometric check</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.reason" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.reason">
         <source>Unlock %@ when re-opening in order to prevent unauthorized access.</source>
         <target>Disblocar %@ al re-apertura pro prevenir accesso non autorisate.</target>
         <note>%@ is app name. Explanation for why the app needs access to biometric information. Prompt is only shown once when the user first tries to enable Face ID to open the app.</note>
       </trans-unit>
-      <trans-unit id="Browser.backLabel" xml:space="preserve">
+      <trans-unit id="Browser.backLabel">
         <source>Back</source>
         <target>Retro</target>
         <note>Accessibility label for the back button</note>
       </trans-unit>
-      <trans-unit id="Browser.copyAddressLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyAddressLabel">
         <source>Copy Address</source>
         <target>Copiar le adresse</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.copyMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyMenuLabel">
         <source>Copy</source>
         <target>Copiar</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.customURLMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.customURLMenuLabel">
         <source>Add Custom URL</source>
         <target>Adder URL personalisate</target>
         <note>Custom URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.forwardLabel" xml:space="preserve">
+      <trans-unit id="Browser.forwardLabel">
         <source>Forward</source>
         <target>Avante</target>
         <note>Accessibility label for the forward button</note>
       </trans-unit>
-      <trans-unit id="Browser.reloadLabel" xml:space="preserve">
+      <trans-unit id="Browser.reloadLabel">
         <source>Reload</source>
         <target>Recargar</target>
         <note>Accessibility label for the reload button</note>
       </trans-unit>
-      <trans-unit id="Browser.settingsLabel" xml:space="preserve">
+      <trans-unit id="Browser.settingsLabel">
         <source>Settings</source>
         <target>Parametros</target>
         <note>Accessibility label for the settings button</note>
       </trans-unit>
-      <trans-unit id="Browser.shareLabel" xml:space="preserve">
+      <trans-unit id="Browser.shareLabel">
         <source>Share</source>
         <target>Compartir</target>
         <note>Accessibility label for the share button</note>
       </trans-unit>
-      <trans-unit id="Browser.stopLabel" xml:space="preserve">
+      <trans-unit id="Browser.stopLabel">
         <source>Stop</source>
         <target>Cessar</target>
         <note>Accessibility label for the stop button</note>
       </trans-unit>
-      <trans-unit id="Cancel" xml:space="preserve">
+      <trans-unit id="Cancel">
         <source>Cancel</source>
         <target>Cancellar</target>
         <note>Label on button to cancel edits</note>
       </trans-unit>
-      <trans-unit id="Done" xml:space="preserve">
+      <trans-unit id="Done">
         <source>Done</source>
         <target>Facite</target>
         <note>Label on button to complete edits</note>
       </trans-unit>
-      <trans-unit id="Edit" xml:space="preserve">
+      <trans-unit id="Edit">
         <source>Edit</source>
         <target>Editar</target>
         <note>Label on button to allow edits</note>
       </trans-unit>
-      <trans-unit id="Error.tryAgainButton" xml:space="preserve">
+      <trans-unit id="Error.tryAgainButton">
         <source>Try again</source>
         <target>Retentar</target>
         <note>Button label to reload the error page</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.cancelTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.cancelTitle">
         <source>Cancel</source>
         <target>Cancellar</target>
         <note>Button label used for cancelling to open another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.messageTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.messageTitle">
         <source>%@ wants to open another App</source>
         <target>%@ vole aperir un altere App</target>
         <note>Dialog title used for opening an external app from Focus. The placeholder string is the app name of either Focus or Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.openTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.openTitle">
         <source>Open</source>
         <target>Aperir</target>
         <note>Button label for opening another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.callButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.callButton">
         <source>Call</source>
         <target>Appellar</target>
         <note>Button label in tel: dialog to call a phone number. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.cancelButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.cancelButton">
         <source>Cancel</source>
         <target>Cancellar</target>
         <note>Button label in external link dialog to cancel the dialog. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.emailButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.emailButton">
         <source>Email</source>
         <target>Email</target>
         <note>Button label in mailto: dialog to send an email. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.messageTitleWithPlaceholder" xml:space="preserve">
+      <trans-unit id="ExternalLink.messageTitleWithPlaceholder">
         <source>You are now leaving %@.</source>
         <target>Tu va exir de %@.</target>
         <note>Dialog title used for Maps/App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreButton">
         <source>Open App Store</source>
         <target>Aperir le Magazin del applicationes</target>
         <note>Button label in App Store URL dialog to open the App Store. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreTitle" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreTitle">
         <source>%@ wants to open the App Store.</source>
         <target>%@ vole aperir le Magazin del applicationes.</target>
         <note>Dialog title used to open App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openMapsButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openMapsButton">
         <source>Open Maps</source>
         <target>Aperi Maps</target>
         <note>Button label in Maps URL dialog to open Maps. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="FindInPage.Done" xml:space="preserve">
+      <trans-unit id="FindInPage.Done">
         <source>Find in page done</source>
         <target>Finite de trovar in pagina</target>
         <note>Accessibility label for done button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.NextResult" xml:space="preserve">
+      <trans-unit id="FindInPage.NextResult">
         <source>Find next in page</source>
         <target>Trovar le proxime in le pagina</target>
         <note>Accessibility label for next result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.PreviousResult" xml:space="preserve">
+      <trans-unit id="FindInPage.PreviousResult">
         <source>Find previous in page</source>
         <target>Trovar le previe in le pagina</target>
         <note>Accessibility label for previous result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FirstRun.lastSlide.buttonLabel" xml:space="preserve">
+      <trans-unit id="FirstRun.lastSlide.buttonLabel">
         <source>OK, Got It!</source>
         <target>De accordo!</target>
         <note>Label on button to dismiss first run UI</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelDescription" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelDescription">
         <source>Automatically block online trackers while you browse. Then tap to erase visited pages, searches, cookies and passwords from your device.</source>
         <target>Bloca automaticamente le traciatores online durante que tu naviga. Pois elimina per un tocco le paginas visitate, recercas, cookies e contrasignos de tu apparato.</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelTagline" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelTagline">
         <source>Browse like no one’s watching.</source>
         <target>Naviga sin sentir te observate.</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="Focus.handoffSyncing" xml:space="preserve">
+      <trans-unit id="Focus.handoffSyncing">
         <source>Apple Handoff is syncing</source>
         <target>Synchronisation de Apple Handoff</target>
         <note>Title for the loading screen when the handoff of clipboard delays Focus launch. “Handoff” should not be localized, see https://support.apple.com/HT204681</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel1" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel1">
         <source>Automatic private browsing.</source>
         <target>Navigation private automatic.</target>
         <note>First label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel2" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel2">
         <source>Browse. Erase. Repeat.</source>
         <target>Naviga. Elimina. Repete.</target>
         <note>Second label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Menu.Close" xml:space="preserve">
+      <trans-unit id="Menu.Close">
         <source>Close</source>
         <target>Clauder</target>
         <note>Button label used to close a menu that displays as a popup.</note>
       </trans-unit>
-      <trans-unit id="Open.Cancel" xml:space="preserve">
+      <trans-unit id="Open.Cancel">
         <source>Cancel</source>
         <target>Cancellar</target>
         <note>Label in share alert to cancel the alert</note>
       </trans-unit>
-      <trans-unit id="Open.Firefox" xml:space="preserve">
+      <trans-unit id="Open.Firefox">
         <source>Firefox (Private Browsing)</source>
         <target>Firefox (Navigation private)</target>
         <note>Label in share alert to open the URL in Firefox</note>
       </trans-unit>
-      <trans-unit id="Open.More" xml:space="preserve">
+      <trans-unit id="Open.More">
         <source>More</source>
         <target>Plus</target>
         <note>Label in share alert to open the full system share menu</note>
       </trans-unit>
-      <trans-unit id="Open.Safari" xml:space="preserve">
+      <trans-unit id="Open.Safari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Label in share alert to open the URL in Safari</note>
       </trans-unit>
-      <trans-unit id="Request Desktop Site" xml:space="preserve">
+      <trans-unit id="Request Desktop Site">
         <source>Request Desktop Site</source>
         <target>Requirer le version scriptorio del sito</target>
         <note>Label for button that requests the desktop version of the currently loaded website.</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsContentBlockers" xml:space="preserve">
+      <trans-unit id="Safari.instructionsContentBlockers">
         <source>Tap Safari, then select Content Blockers</source>
         <target>Tocca Safari, pois selige Blocatores de contento</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsEnable" xml:space="preserve">
+      <trans-unit id="Safari.instructionsEnable">
         <source>Enable %@</source>
         <target>Activar %@</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsNotEnabled" xml:space="preserve">
+      <trans-unit id="Safari.instructionsNotEnabled">
         <source>%@ is not enabled.</source>
         <target>%@ non es activate.</target>
         <note>Error label when the blocker is not enabled, shown in the intro and main app when disabled</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsOpen" xml:space="preserve">
+      <trans-unit id="Safari.instructionsOpen">
         <source>Open Settings App</source>
         <target>Aperi le parametros</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Save" xml:space="preserve">
+      <trans-unit id="Save">
         <source>Save</source>
         <target>Salvar</target>
         <note>Save button label</note>
       </trans-unit>
-      <trans-unit id="SearchEngine.addEngineError" xml:space="preserve">
+      <trans-unit id="SearchEngine.addEngineError">
         <source>That didn't work. Try replacing the search term with this: %s.</source>
         <target>Illo non functiona. Prova a supplantar le termino de recerca con isto: %s.</target>
         <note>Label for error state when entering an invalid search engine URL. %s is a search term in a URL.</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptDisable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptDisable">
         <source>No</source>
         <target>No</target>
         <note>Label for disable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptEnable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptEnable">
         <source>Yes</source>
         <target>Si</target>
         <note>Label for enable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptMessage" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptMessage">
         <source>To get suggestions, %@ needs to send what you type in the address bar to the search engine.</source>
         <target>Pro obtener suggestiones, %@ debe inviar lo que tu scribe in le barra de adresses verso le motor de recerca.</target>
         <note>%@ is the name of the app (Focus / Klar). Label for search suggestions prompt message</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptTitle" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptTitle">
         <source>Show Search Suggestions?</source>
         <target>Monstrar le suggestiones de recerca?</target>
         <note>Title for search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButton" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButton">
         <source>Add Another Search Engine</source>
         <target>Adder un altere motor de recerca</target>
         <note>Text for button to add another search engine in settings</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus">
         <source>+ Add Another Search Engine</source>
         <target>+ Adder un altere motor de recerca</target>
         <note>Text for button to add another search engine in settings with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineTitle" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineTitle">
         <source>Add Search Engine</source>
         <target>Adder un motor de recerca</target>
         <note>Title on add search engine settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.InstalledSearchEngines" xml:space="preserve">
+      <trans-unit id="Settings.Search.InstalledSearchEngines">
         <source>INSTALLED SEARCH ENGINES</source>
         <target>MOTORES de RECERCA INSTALLATE</target>
         <note>Header for rows of installed search engines</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NameToDisplay" xml:space="preserve">
+      <trans-unit id="Settings.Search.NameToDisplay">
         <source>Name to display</source>
         <target>Nomine a monstrar</target>
         <note>Label for input field for the name of the search engine to be added</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NewSearchEngineAdded" xml:space="preserve">
+      <trans-unit id="Settings.Search.NewSearchEngineAdded">
         <source>New Search Engine Added.</source>
         <target>Nove motor de recerca addite.</target>
         <note>Toast displayed after adding a search engine</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.RestoreEngine" xml:space="preserve">
+      <trans-unit id="Settings.Search.RestoreEngine">
         <source>Restore Default Search Engines</source>
         <target>Restaurar le motores de recerca predefinite</target>
         <note>Label for button to bring deleted default engines back</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchEngineName" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchEngineName">
         <source>Search engine name</source>
         <target>Nomine del motor de recerca</target>
         <note>Placeholder text for input of new search engine name</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplate" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplate">
         <source>Search string to use</source>
         <target>Fila de characteres de recerca a usar</target>
         <note>Label for input of search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplatePlaceholder" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplatePlaceholder">
         <source>Paste or enter search string. If necessary, replace search term with: %s.</source>
         <target>Colla o insere le catena de recerca. Si necessari, reimplacia le termino de recerca per: %s.</target>
         <note>Placeholder text for input of new search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.autocompleteSection" xml:space="preserve">
+      <trans-unit id="Settings.autocompleteSection">
         <source>URL Autocomplete</source>
         <target>Auto-completamento del URL</target>
         <note>Title for the URL Autocomplete row</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherMessage" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherMessage">
         <source>Blocking other content trackers may break some videos and web pages.</source>
         <target>Blocar altere traciatores de contento pote render mal-functionate alcun videos e paginas web.</target>
         <note>Alert message shown when toggling the Content blocker</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherNo2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherNo2">
         <source>Cancel</source>
         <target>Cancellar</target>
         <note>Button label for declining Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherYes2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherYes2">
         <source>Block Content Trackers</source>
         <target>Blocar le traciatores de contento</target>
         <note>Button label for accepting Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSearchSuggestion" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSearchSuggestion">
         <source>%@ will send what you type in the address bar to your search engine.</source>
         <target>%@ inviara a tu motor de recerca lo que tu scribe in le barra de adresse.</target>
         <note>Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSendUsageData">
         <source>Mozilla strives to collect only what we need to provide and improve %@ for everyone.</source>
         <target>Mozilla se effortia a colliger solmente le informationes necessari pro fornir e meliorar %@ pro totes.</target>
         <note>Description associated to the Send Usage Data toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.learnMore" xml:space="preserve">
+      <trans-unit id="Settings.learnMore">
         <source>Learn more.</source>
         <target>Saper plus.</target>
         <note>Subtitle for Send Anonymous Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.rate" xml:space="preserve">
+      <trans-unit id="Settings.rate">
         <source>Rate %@</source>
         <target>Valuta %@</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, allows the user to leave a review for the app on the app store.</note>
       </trans-unit>
-      <trans-unit id="Settings.safariTitle" xml:space="preserve">
+      <trans-unit id="Settings.safariTitle">
         <source>SAFARI INTEGRATION</source>
         <target>INTEGRATION CON SAFARI</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.screenTitle" xml:space="preserve">
+      <trans-unit id="Settings.screenTitle">
         <source>Settings</source>
         <target>Parametros</target>
         <note>Title for settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchLabel" xml:space="preserve">
+      <trans-unit id="Settings.searchLabel">
         <source>Search Engine</source>
         <target>Motor de recerca</target>
         <note>Label for the search engine in the search screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchSuggestions" xml:space="preserve">
+      <trans-unit id="Settings.searchSuggestions">
         <source>Get Search Suggestions</source>
         <target>Obtener suggestiones de recerca</target>
         <note>Label for the Search Suggestions toggle row</note>
       </trans-unit>
-      <trans-unit id="Settings.searchTitle2" xml:space="preserve">
+      <trans-unit id="Settings.searchTitle2">
         <source>SEARCH</source>
         <target>RECERCA</target>
         <note>Title for the search selection screen</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionIntegration" xml:space="preserve">
+      <trans-unit id="Settings.sectionIntegration">
         <source>INTEGRATION</source>
         <target>INTEGRATION</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionMozilla" xml:space="preserve">
+      <trans-unit id="Settings.sectionMozilla">
         <source>MOZILLA</source>
         <target>MOZILLA</target>
         <note>Section label for Mozilla toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPerformance" xml:space="preserve">
+      <trans-unit id="Settings.sectionPerformance">
         <source>PERFORMANCE</source>
         <target>PERFORMANCES</target>
         <note>Section label for performance toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPrivacy" xml:space="preserve">
+      <trans-unit id="Settings.sectionPrivacy">
         <source>PRIVACY</source>
         <target>CONFIDENTIALITATE</target>
         <note>Section label for privacy toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionSecurity" xml:space="preserve">
+      <trans-unit id="Settings.sectionSecurity">
         <source>SECURITY</source>
         <target>SECURITATE</target>
         <note>Header label for security toggles displayed in the settings menu</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAds2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAds2">
         <source>Advertising</source>
         <target>Publicitate</target>
         <note>Label for the checkbox to toggle Advertising trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAnalytics2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAnalytics2">
         <source>Analytics</source>
         <target>Analyse datos</target>
         <note>Label for the checkbox to toggle Analytics trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockFonts" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockFonts">
         <source>Block web fonts</source>
         <target>Blocar le typos de character de web</target>
         <note>Label for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockOther2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockOther2">
         <source>Content</source>
         <target>Contento</target>
         <note>Label for the checkbox to toggle Other trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockSocial2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockSocial2">
         <source>Social</source>
         <target>Social</target>
         <note>Label for the checkbox to toggle Social trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceID" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceID">
         <source>Use Face ID to unlock app</source>
         <target>Usar Face ID pro disblocar le application</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceIDDescription">
         <source>Face ID can unlock %@ if a URL is already open in the app</source>
         <target>Face ID pote disblocar %@ si un URL es jam aperte in le application</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Face ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleHomeScreenTips" xml:space="preserve">
+      <trans-unit id="Settings.toggleHomeScreenTips">
         <source>Show home screen tips</source>
         <target>Monstrar le suggestiones del pagina principal</target>
         <note>Show home screen tips toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleOtherSubtitle" xml:space="preserve">
+      <trans-unit id="Settings.toggleOtherSubtitle">
         <source>May break some videos and Web pages</source>
         <target>Pote causar problemas a alcun videos e paginas web</target>
         <note>Label subtitle for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSafari" xml:space="preserve">
+      <trans-unit id="Settings.toggleSafari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Safari toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.toggleSendUsageData">
         <source>Send usage data</source>
         <target>Inviar datos de uso</target>
         <note>Label for Send Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchID" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchID">
         <source>Use Touch ID to unlock app</source>
         <target>Usar Touch ID pro disblocar le application</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchIDDescription">
         <source>Touch ID can unlock %@ if a URL is already open in the app</source>
         <target>Touch ID pote disblocar %@ si un URL es jam aperte in le application</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Touch ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOff" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOff">
         <source>Off</source>
         <target>Inactive</target>
         <note>Status off for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOn" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOn">
         <source>On</source>
         <target>Active</target>
         <note>Status on for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.whatsNewTitle" xml:space="preserve">
+      <trans-unit id="Settings.whatsNewTitle">
         <source>What’s New</source>
         <target>Novas</target>
         <note>Title for What's new screen</note>
       </trans-unit>
-      <trans-unit id="Settinsg.siriShortcutsTitle" xml:space="preserve">
+      <trans-unit id="Settinsg.siriShortcutsTitle">
         <source>SIRI SHORTCUTS</source>
         <target>SIRI VIAS BREVE</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.FindInPage" xml:space="preserve">
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Trovar in le pagina</target>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.GetFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.GetFirefox">
         <source>Get the Firefox App</source>
         <target>Discarga le application Firefox</target>
         <note>Text for the share menu option when a user wants to open a page in Firefox but doesn’t have it installed. This string will not wrap in the interface. Instead, it will truncate. To prevent this, please keep the localized string to 18 or fewer characters. If your string runs longer than 18 characters, you can use 'Get Firefox' as the basis for your string. However, if at all possible, we’d like to signal to the user that they will be going to the App Store and installing the application from there. That is why we are using Get and App in the en-US string.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.PageActions" xml:space="preserve">
+      <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <target>Actiones del pagina</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestDesktop" xml:space="preserve">
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
         <target>Requirer le version scriptorio del sito</target>
         <note>Text for the share menu option when a user wants to reload the site as a desktop</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestMobile" xml:space="preserve">
+      <trans-unit id="ShareMenu.RequestMobile">
         <source>Request Mobile Site</source>
         <target>Requirer le version mobile</target>
         <note>Text for the share menu option when a user wants to reload the site as a mobile device</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenChrome" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenChrome">
         <source>Open in Chrome</source>
         <target>Aperir in Chrome</target>
         <note>Text for the share menu option when a user wants to open the current website in the Chrome app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenFirefox">
         <source>Open in Firefox</source>
         <target>Aperir in Firefox</target>
         <note>Text for the share menu option when a user wants to open the current website in the Firefox app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenSafari" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenSafari">
         <source>Open in Safari</source>
         <target>Aperir in Safari</target>
         <note>Text for the share menu option when a user wants to open the current website in the Safari app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.SharePage" xml:space="preserve">
+      <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <target>Compartir le pagina con...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
       </trans-unit>
-      <trans-unit id="Siri.add" xml:space="preserve">
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
+      </trans-unit>
+      <trans-unit id="Siri.add">
         <source>Add</source>
         <target>Adder</target>
         <note>Button to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.addTo" xml:space="preserve">
+      <trans-unit id="Siri.addTo">
         <source>Add to Siri</source>
         <target>Adder a Siri</target>
         <note>Button to add a specified shortcut option to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.editOpenUrl" xml:space="preserve">
+      <trans-unit id="Siri.editOpenUrl">
         <source>Re-Record or Delete Shortcut</source>
         <target>Re-registra o dele le instantaneo</target>
         <note>Label for button to edit the Siri phrase or delete the Siri functionality.</note>
       </trans-unit>
-      <trans-unit id="Siri.erase" xml:space="preserve">
+      <trans-unit id="Siri.erase">
         <source>Erase</source>
         <target>Eliminar</target>
         <note>Title of option in settings to set up Siri to erase</note>
       </trans-unit>
-      <trans-unit id="Siri.eraseAndOpen" xml:space="preserve">
+      <trans-unit id="Siri.eraseAndOpen">
         <source>Erase &amp; Open</source>
         <target>Eliminar e aperir</target>
         <note>Title of option in settings to set up Siri to erase and then open the app.</note>
       </trans-unit>
-      <trans-unit id="Siri.favoriteUrl" xml:space="preserve">
+      <trans-unit id="Siri.favoriteUrl">
         <source>Open Favorite Site</source>
         <target>Aperir le sito preferite</target>
         <note>Title for screen to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.openURL" xml:space="preserve">
+      <trans-unit id="Siri.openURL">
         <source>Open Favorite Site</source>
         <target>Aperir le sito preferite</target>
         <note>Title of option in settings to set up Siri to open a specified URL in Focus/Klar.</note>
       </trans-unit>
-      <trans-unit id="Siri.urlToOpen" xml:space="preserve">
+      <trans-unit id="Siri.urlToOpen">
         <source>URL to open</source>
         <target>URL a aperir</target>
         <note>Label for input to set a favorite URL to be opened by Siri.</note>
       </trans-unit>
-      <trans-unit id="URL.addToAutocompleteLabel" xml:space="preserve">
+      <trans-unit id="URL.addToAutocompleteLabel">
         <source>Add link to autocomplete</source>
         <target>Adde ligamine pro autocompletar</target>
         <note>Label displayed for button used as a shortcut to add a link to the list of URLs to autocomplete.</note>
       </trans-unit>
-      <trans-unit id="URL.cancelLabel" xml:space="preserve">
+      <trans-unit id="URL.cancelLabel">
         <source>Cancel</source>
         <target>Cancellar</target>
         <note>Label for cancel button shown when entering a URL or search</note>
       </trans-unit>
-      <trans-unit id="URL.contextMenu" xml:space="preserve">
+      <trans-unit id="URL.contextMenu">
         <source>Paste &amp; Go</source>
         <target>Collar e ir</target>
         <note>Text for the URL context menu when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.eraseButtonLabel" xml:space="preserve">
+      <trans-unit id="URL.eraseButtonLabel">
         <source>ERASE</source>
         <target>ELIMINA</target>
         <note>Erase button in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.eraseMessageLabel2" xml:space="preserve">
+      <trans-unit id="URL.eraseMessageLabel2">
         <source>Browsing history cleared</source>
         <target>Chronologia de navigation clarate</target>
         <note>Message shown after pressing the Erase button</note>
       </trans-unit>
-      <trans-unit id="URL.findOnPageLabel" xml:space="preserve">
+      <trans-unit id="URL.findOnPageLabel">
         <source>Find in page: %@</source>
         <target>Trovar in le pagina: %@</target>
         <note>Label displayed for find in page button when typing in the URL Bar. %@ is any text the user has typed into the URL bar that they want to find on the current page.</note>
       </trans-unit>
-      <trans-unit id="URL.paste" xml:space="preserve">
+      <trans-unit id="URL.paste">
         <source>Paste</source>
         <target>Collar</target>
         <note>Text for a menu displayed from the bottom of the screen when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.placeholderText" xml:space="preserve">
+      <trans-unit id="URL.placeholderText">
         <source>Search or enter address</source>
         <target>Insere un adresse o face un recerca</target>
         <note>Placeholder text shown in the URL bar before the user navigates to a page</note>
       </trans-unit>
-      <trans-unit id="URL.searchLabel" xml:space="preserve">
+      <trans-unit id="URL.searchLabel">
         <source>Search for %@</source>
         <target>Cercar %@</target>
         <note>Label displayed for search button when typing in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="URL.trackersBlockedLabel">
         <source>Trackers blocked</source>
         <target>Traciatores blocate</target>
         <note>Text for the URL bar showing the number of trackers blocked on a webpage.</note>
       </trans-unit>
-      <trans-unit id="actionSheet.openIn" xml:space="preserve">
+      <trans-unit id="actionSheet.openIn">
         <source>Open in %@</source>
         <target>Aperir in %@</target>
         <note>Title for action sheet item to open the current page in another application. Placeholder is the name of the application to open the current page.</note>
       </trans-unit>
-      <trans-unit id="browser.copyAddressToast" xml:space="preserve">
+      <trans-unit id="browser.copyAddressToast">
         <source>URL Copied To Clipboard</source>
         <target>URL copiate in le planchetta</target>
         <note>Toast displayed after a URL has been copied to the clipboard</note>
       </trans-unit>
-      <trans-unit id="browserShortcutDescription.selectLocationBar" xml:space="preserve">
+      <trans-unit id="browserShortcutDescription.selectLocationBar">
         <source>Select Location Bar</source>
         <target>Seliger le barra de adresse</target>
         <note>Label to display in the Discoverability overlay for keyboard shortcuts</note>
       </trans-unit>
-      <trans-unit id="contextMenu.clipboardLink" xml:space="preserve">
+      <trans-unit id="contextMenu.clipboardLink">
         <source>Link you copied: %@</source>
         <target>Ligamine que tu ha copiate: %@</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.copyImageTitle">
         <source>Copy Image</source>
         <target>Copiar le imagine</target>
         <note>Text for the context menu when a user wants to copy an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyLink" xml:space="preserve">
+      <trans-unit id="contextMenu.copyLink">
         <source>Copy Link</source>
         <target>Copiar le ligamine</target>
         <note>Text for the context menu when a user wants to copy a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.linkCopied" xml:space="preserve">
+      <trans-unit id="contextMenu.linkCopied">
         <source>Link you copied: </source>
         <target>Ligamine que tu ha copiate:</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.saveImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.saveImageTitle">
         <source>Save Image</source>
         <target>Salvar le imagine</target>
         <note>Text for the context menu when a user wants to save an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.shareLinkTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.shareLinkTitle">
         <source>Share Link</source>
         <target>Compartir le ligamine</target>
         <note>Text for the context menu when a user wants to share a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="externalAppLinkWithAppName.messageTitle" xml:space="preserve">
+      <trans-unit id="externalAppLinkWithAppName.messageTitle">
         <source>%1$@ wants to open %2$@</source>
         <target>%1$@ vole aperir %2$@</target>
         <note>Dialog title used for opening an external app from Focus. First placeholder string is the app name of either Focus or Klar and the second placeholder string specifies the app it wants to open.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.description" xml:space="preserve">
+      <trans-unit id="photosPermission.description">
         <source>This lets you save images to your Camera Roll</source>
         <target>Isto te permitte de salvar le imagines in tu rolo de camera</target>
         <note>Description for dialog used for requesting a user to enable access to Photos.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.openSettings" xml:space="preserve">
+      <trans-unit id="photosPermission.openSettings">
         <source>Open Settings</source>
         <target>Aperir le parametros</target>
         <note>Title for button that takes the user to system settings</note>
       </trans-unit>
-      <trans-unit id="photosPermission.title" xml:space="preserve">
+      <trans-unit id="photosPermission.title">
         <source>“%@” Would Like to Access Your Photos</source>
         <target>“%@” desira acceder a tu photos</target>
         <note>Dialog title used for requesting a user to enable access to Photos. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="settings.Search.SearchTemplateExample" xml:space="preserve">
+      <trans-unit id="settings.Search.SearchTemplateExample">
         <source>Example: searchengineexample.com/search/?q=%s</source>
         <target>Exemplo: searchengineexample.com/search/?q=%s</target>
         <note>Text displayed as an example of the template to add a search engine.</note>
       </trans-unit>
-      <trans-unit id="share" xml:space="preserve">
+      <trans-unit id="share">
         <source>Share</source>
         <target>Compartir</target>
         <note>Text for a share button</note>
       </trans-unit>
-      <trans-unit id="shareMenu.copyAddress" xml:space="preserve">
+      <trans-unit id="shareMenu.copyAddress">
         <source>Copy Address</source>
         <target>Copiar le adresse</target>
         <note>Text for the share menu when a user wants to copy a URL.</note>
       </trans-unit>
-      <trans-unit id="touchId.reason" xml:space="preserve">
+      <trans-unit id="touchId.reason">
         <source>Use Touch ID to return to %@</source>
         <target>Usa ID de tocco pro retornar a %@</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.adTrackersLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.adTrackersLabel">
         <source>Ad trackers</source>
         <target>Traciatores publicitari</target>
         <note>Label for ad trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.analyticTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.analyticTrackerLabel">
         <source>Analytic trackers</source>
         <target>Traciatores analytic</target>
         <note>label for analytic trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.contentTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>
         <target>Traciatores de contento</target>
         <note>label for content trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.disabledLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.disabledLabel">
         <source>Tracking Protection off</source>
         <target>Protection contra le traciamento disactivate</target>
         <note>text showing the tracking protection is disabled.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.label" xml:space="preserve">
+      <trans-unit id="trackingProtection.label">
         <source>Tracking Protection</source>
         <target>Protection contra le traciamento</target>
         <note>Title for the tracking settings page to change what trackers are blocked.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.labelDescription" xml:space="preserve">
+      <trans-unit id="trackingProtection.labelDescription">
         <source>Turning this off may fix some site problems</source>
         <target>Disactivar isto pote remediar alicun problemas del sito</target>
         <note>Description/subtitle for the tracking protection label.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.learnMore" xml:space="preserve">
+      <trans-unit id="trackingProtection.learnMore">
         <source>Learn More</source>
         <target>Saper plus</target>
         <note>Text for the button to learn more about Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.moreSettings" xml:space="preserve">
+      <trans-unit id="trackingProtection.moreSettings">
         <source>More Settings</source>
         <target>Altere parametros</target>
         <note>Text for the button that closes the Shield Data and opens the regular Settings screen.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.socialTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.socialTrackerLabel">
         <source>Social trackers</source>
         <target>Traciatores social</target>
         <note>label for social trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOff" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOff">
         <source>Protections are OFF for this session</source>
         <target>Protectiones es INACTIVE pro iste session</target>
         <note>Text for the status off from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOn" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOn">
         <source>Protections are ON for this session</source>
         <target>Protectiones es ACTIVE pro iste session</target>
         <note>Text for the status on from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleDescription1" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleDescription1">
         <source>Disable until you close %@ or tap ERASE.</source>
         <target>Disactiva usque %@ es claudite o tocca ELIMINA.</target>
         <note>Description for the tracking protection toggle. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleLabel2">
         <source>Enhanced Tracking Protection</source>
         <target>Protection antitraciamento reinfortiate</target>
         <note>Text for the toggle that enables/disables tracking protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackerDescriptionLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackerDescriptionLabel2">
         <source>Keep your data to yourself. %@ protects you from many of the most common trackers that follow what you do online.</source>
         <target>Mantene tu datos pro te mesme. %@ te protege contra multe del plus commun traciatores que seque lo que tu face online.
 </target>
         <note>General description of tracking protection settings, which is displayed underneath the trackers preferences in Settings. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersBlockedLabel">
         <source>Trackers blocked since %@</source>
         <target>Traciatores blocate desde %@</target>
         <note>Text for tracking protection screen showing the number of trackers blocked since the app install. The placeholder is replaced with the install date of the application.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersHeader" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersHeader">
         <source>Trackers and scripts to block</source>
         <target>Traciatores e scripts a blocar</target>
         <note>Text for the header of trackers section from Tracking Protection.</note>
@@ -1079,7 +1098,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="SettingsBundle.Licenses" xml:space="preserve">
+      <trans-unit id="SettingsBundle.Licenses">
         <source>Licenses</source>
         <target>Licentias</target>
         <note>The title of the Licenses setting in the settings that Focus shows in the global iOS Settings app.</note>
@@ -1087,3 +1106,4 @@
     </body>
   </file>
 </xliff>
+

--- a/id/focus-ios.xliff
+++ b/id/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>PINTASAN SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Temukan di Laman</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>Aksi Laman</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>Bagikan Laman Dengan...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>Pelacak analitis</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/is/focus-ios.xliff
+++ b/is/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>SIRI FLÝTILEIÐIR</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Finna á síðu</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>Síðu aðgerðir</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>Deila síðu með…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>Greininga rekjarar</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/it/focus-ios.xliff
+++ b/it/focus-ios.xliff
@@ -761,6 +761,10 @@
         <target>SCORCIATOIE SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Trova nella pagina</target>
@@ -775,6 +779,10 @@
         <source>Page Actions</source>
         <target>Azioni per la pagina corrente</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -805,6 +813,10 @@
         <source>Share Page With...</source>
         <target>Condividi pagina con…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -990,6 +1002,14 @@
         <source>Analytic trackers</source>
         <target>Traccianti analitici</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/ja/focus-ios.xliff
+++ b/ja/focus-ios.xliff
@@ -151,7 +151,6 @@
       </trans-unit>
       <trans-unit id="About.safariBullet2">
         <source>Block web fonts to reduce page size</source>
-        <target>ウェブフォントをブロックしてページのデータ転送量を削減します</target>
         <note>Label on About screen</note>
       </trans-unit>
       <trans-unit id="About.safariBulletHeader">
@@ -601,7 +600,6 @@
       </trans-unit>
       <trans-unit id="Settings.blockOtherMessage">
         <source>Blocking other content trackers may break some videos and web pages.</source>
-        <target>他の追跡コンテンツをブロックすると、動画やウェブページが正常に表示されない場合があります。</target>
         <note>Alert message shown when toggling the Content blocker</note>
       </trans-unit>
       <trans-unit id="Settings.blockOtherNo2">
@@ -692,7 +690,6 @@
       </trans-unit>
       <trans-unit id="Settings.toggleBlockFonts">
         <source>Block web fonts</source>
-        <target>ウェブフォントをブロック</target>
         <note>Label for toggle on main screen</note>
       </trans-unit>
       <trans-unit id="Settings.toggleBlockOther2">
@@ -761,6 +758,10 @@
         <target>SIRI ショートカット</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>ページ内検索</target>
@@ -775,6 +776,10 @@
         <source>Page Actions</source>
         <target>ページ操作</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -805,6 +810,10 @@
         <source>Share Page With...</source>
         <target>ページを共有...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -990,6 +999,14 @@
         <source>Analytic trackers</source>
         <target>アクセス解析</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/ka/focus-ios.xliff
+++ b/ka/focus-ios.xliff
@@ -151,7 +151,6 @@
       </trans-unit>
       <trans-unit id="About.safariBullet2">
         <source>Block web fonts to reduce page size</source>
-        <target>შეზღუდეთ ვებშრიფტები, გვერდის ზომის შესამცირებლად</target>
         <note>Label on About screen</note>
       </trans-unit>
       <trans-unit id="About.safariBulletHeader">
@@ -601,7 +600,6 @@
       </trans-unit>
       <trans-unit id="Settings.blockOtherMessage">
         <source>Blocking other content trackers may break some videos and web pages.</source>
-        <target>შიგთავსის სხვა მეთვალყურე ელემენტების შეზღუდვის შედეგად, შესაძლოა ვიდეოებმა გამართულად ვერ იმუშაოს ვებგვერდებზე.</target>
         <note>Alert message shown when toggling the Content blocker</note>
       </trans-unit>
       <trans-unit id="Settings.blockOtherNo2">
@@ -692,7 +690,6 @@
       </trans-unit>
       <trans-unit id="Settings.toggleBlockFonts">
         <source>Block web fonts</source>
-        <target>საიტის შრიფტების შეზღუდვა</target>
         <note>Label for toggle on main screen</note>
       </trans-unit>
       <trans-unit id="Settings.toggleBlockOther2">
@@ -761,6 +758,10 @@
         <target>SIRI მალსახმობები</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>პოვნა გვერდზე</target>
@@ -775,6 +776,10 @@
         <source>Page Actions</source>
         <target>ვებგვერდზე მოქმედებები</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -805,6 +810,10 @@
         <source>Share Page With...</source>
         <target>გვერდის გაზიარება…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -990,6 +999,14 @@
         <source>Analytic trackers</source>
         <target>სტატისტიკის აღმრიცხველი</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/kab/focus-ios.xliff
+++ b/kab/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>INEGZUMEN SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Nadi deg usebter</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>Tigawin i usebter</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>Bḍu asebter d…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>Ineḍfaṛen n tiddadanin</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/kk/focus-ios.xliff
+++ b/kk/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>SIRI ЖАРЛЫҚТАРЫ</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Беттен табу</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>Бет әрекеттері</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>Бетті көмегімен бөлісу...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>Аналитикалық трекерлер</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/kn/focus-ios.xliff
+++ b/kn/focus-ios.xliff
@@ -744,6 +744,10 @@
         <target>SIRI SHORTCUTS</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>ಪುಟದಲ್ಲಿ ಹುಡುಕು</target>
@@ -758,6 +762,10 @@
         <source>Page Actions</source>
         <target>ಪುಟದ ಕಾರ್ಯಗಳು</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -788,6 +796,10 @@
         <source>Share Page With...</source>
         <target>ಇದರೊಂದಿಗೆ ಪುಟ ಹಂಚಿಕೊಳ್ಳಿ...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -972,6 +984,14 @@
         <source>Analytic trackers</source>
         <target>ವಿಶ್ಲೇಷಣಾತ್ಮಕ ಅನ್ವೇಷಕಗಳು</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/ko/focus-ios.xliff
+++ b/ko/focus-ios.xliff
@@ -761,6 +761,10 @@
         <target>SIRI 단축키</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>페이지내 검색</target>
@@ -775,6 +779,10 @@
         <source>Page Actions</source>
         <target>페이지 작업</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -805,6 +813,10 @@
         <source>Share Page With...</source>
         <target>페이지 공유...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -990,6 +1002,14 @@
         <source>Analytic trackers</source>
         <target>분석용 추적기</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/lo/focus-ios.xliff
+++ b/lo/focus-ios.xliff
@@ -725,6 +725,10 @@
         <source>SIRI SHORTCUTS</source>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
@@ -738,6 +742,10 @@
         <source>Page Actions</source>
         <target>ການກະທຳຂອງຫນ້າ</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -765,6 +773,10 @@
       <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -935,6 +947,14 @@
         <source>Analytic trackers</source>
         <target>ຕົວຕິດຕາມການວິເຄາະ</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/lt/focus-ios.xliff
+++ b/lt/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>„SIRI“ KOMANDOS</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Rasti tinklalapyje</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>Tinklalapio veiksmai</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>Dalintis naudojant…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>Analizės stebėjimo elementai</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/lv/focus-ios.xliff
+++ b/lv/focus-ios.xliff
@@ -655,6 +655,10 @@
         <source>SIRI SHORTCUTS</source>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
@@ -666,6 +670,10 @@
       <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -690,6 +698,10 @@
       <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -838,6 +850,14 @@
       <trans-unit id="trackingProtection.analyticTrackerLabel">
         <source>Analytic trackers</source>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/mr/focus-ios.xliff
+++ b/mr/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>SIRI SHORTCUTS</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>पृष्ठामध्ये शोधा</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>पृष्ठाच्या कृती</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>यासोबत पृष्ठ शेअर करा...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>अॅनालिटिक ट्रॅकर्स</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/ms/focus-ios.xliff
+++ b/ms/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>SIRI SHORTCUTS</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Cari dalam Halaman</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>Tindakan Halaman</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -800,6 +808,10 @@
         <source>Share Page With...</source>
         <target>Kongsi Halaman Dengan...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -984,6 +996,14 @@
         <source>Analytic trackers</source>
         <target>Penjejak analitik</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/my/focus-ios.xliff
+++ b/my/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>SIRI နည်းလမ်းတိုများ</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>စာမျက်နှာထဲတွင် ရှာပါ</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>စာမျက်နှာဆိုင်ရာ လုပ်ဆောင်ချက်များ</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>၎င်းနှင့်အတူ မျှဝေရန် ...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>သရုပ်ခွဲခြေရာခံကိရိယာများ</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/nb-NO/focus-ios.xliff
+++ b/nb-NO/focus-ios.xliff
@@ -761,6 +761,10 @@
         <target>SIRI-SNARVEIER</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Søk på siden</target>
@@ -775,6 +779,10 @@
         <source>Page Actions</source>
         <target>Sidehandlinger</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -805,6 +813,10 @@
         <source>Share Page With...</source>
         <target>Del side med…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -990,6 +1002,14 @@
         <source>Analytic trackers</source>
         <target>Analyse-sporere</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/ne-NP/focus-ios.xliff
+++ b/ne-NP/focus-ios.xliff
@@ -707,6 +707,10 @@
         <source>SIRI SHORTCUTS</source>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
@@ -719,6 +723,10 @@
       <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -743,6 +751,10 @@
       <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -911,6 +923,14 @@
         <source>Analytic trackers</source>
         <target>विश्लेषणात्मक ट्रयाकरहरू</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/nl/focus-ios.xliff
+++ b/nl/focus-ios.xliff
@@ -1,36 +1,35 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Blockzilla/en.lproj/InfoPlist.strings" source-language="en" target-language="nl" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="NSCameraUsageDescription" xml:space="preserve">
+      <trans-unit id="NSCameraUsageDescription">
         <source>This lets you take and upload photos.</source>
         <target>Hiermee kunt u foto’s maken en uploaden.</target>
         <note>Privacy - Camera Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSFaceIDUsageDescription" xml:space="preserve">
+      <trans-unit id="NSFaceIDUsageDescription">
         <source>This lets you unlock the app.</source>
         <target>Hiermee kunt u de app ontgrendelen.</target>
         <note>Privacy - Face ID Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSLocationWhenInUseUsageDescription" xml:space="preserve">
+      <trans-unit id="NSLocationWhenInUseUsageDescription">
         <source>Websites you visit may request your location.</source>
         <target>Websites die u bezoekt kunnen om uw locatie vragen.</target>
         <note>Privacy - Location When In Use Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSMicrophoneUsageDescription" xml:space="preserve">
+      <trans-unit id="NSMicrophoneUsageDescription">
         <source>This lets you take and upload videos.</source>
         <target>Hiermee kunt u video’s maken en uploaden.</target>
         <note>Privacy - Microphone Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSPhotoLibraryAddUsageDescription" xml:space="preserve">
+      <trans-unit id="NSPhotoLibraryAddUsageDescription">
         <source>This lets you save and upload photos.</source>
         <target>Hiermee kunt u foto’s opslaan en uploaden.</target>
         <note>Privacy - Photo Library Additions Usage Description</note>
       </trans-unit>
-      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen" xml:space="preserve">
+      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen">
         <source>Erase and Open</source>
         <target>Wissen en openen</target>
         <note>This is the menu item that appears when you long press the Focus icon on the phone home screen.</note>
@@ -42,7 +41,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intents.Erase.Title" xml:space="preserve">
+      <trans-unit id="Intents.Erase.Title">
         <source>Erase</source>
         <target>Wissen</target>
         <note>Title of the Erase intent.</note>
@@ -54,42 +53,42 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intro.Slides.History.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Description">
         <source>Clear your entire browsing session history, passwords, cookies anytime with a single tap.</source>
         <target>Wis uw volledige surfgeschiedenis, wachtwoorden en cookies wanneer u wilt met één tik.</target>
         <note>Description for the 'History' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.History.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Title">
         <source>Your history is history</source>
         <target>Uw geschiedenis behoort tot het verleden</target>
         <note>Title for the third  panel 'History' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Next.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Next.Button">
         <source>Next</source>
         <target>Volgende</target>
         <note>Button to go to the next card in Focus onboarding.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Description">
         <source>Searching for something different? Choose a different search engine.</source>
         <target>Op zoek naar iets anders? Kies een andere zoekmachine.</target>
         <note>Description for the 'Favorite Search Engine' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Title">
         <source>Your search, your way</source>
         <target>Zoeken op uw manier</target>
         <note>Title for the second  panel 'Search' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Skip.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Skip.Button">
         <source>Skip</source>
         <target>Overslaan</target>
         <note>Button to skip onboarding in Focus</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Description">
         <source>Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times.</source>
         <target>Breng privénavigatie naar een hoger niveau. Blokkeer advertenties en andere inhoud die u op websites kunnen volgen en laadtijden van pagina’s verlengen.</target>
         <note>Description for the 'Welcome' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Title">
         <source>Power up your privacy</source>
         <target>Vergroot uw privacy</target>
         <note>Title for the first panel 'Welcome' in the First Run tour.</note>
@@ -101,972 +100,992 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="About.learnMoreButton" xml:space="preserve">
+      <trans-unit id="About.learnMoreButton">
         <source>Learn more</source>
         <target>Meer info</target>
         <note>Button on About screen</note>
       </trans-unit>
-      <trans-unit id="About.missionLabel" xml:space="preserve">
+      <trans-unit id="About.missionLabel">
         <source>%@ is produced by Mozilla. Our mission is to foster a healthy, open Internet.</source>
         <target>%@ wordt gemaakt door Mozilla. Onze missie is het verzorgen van een gezond en open internet.</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet1" xml:space="preserve">
+      <trans-unit id="About.privateBullet1">
         <source>Search and browse right in the app</source>
         <target>Rechtstreeks vanuit de app zoeken en browsen</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet2" xml:space="preserve">
+      <trans-unit id="About.privateBullet2">
         <source>Block trackers (or update settings to allow trackers)</source>
         <target>Trackers blokkeren (of instellingen bijwerken om ze toe te staan)</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet3" xml:space="preserve">
+      <trans-unit id="About.privateBullet3">
         <source>Erase to delete cookies as well as search and browsing history</source>
         <target>Wissen verwijdert zowel cookies als zoek- en navigatiegeschiedenis</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBulletHeader" xml:space="preserve">
+      <trans-unit id="About.privateBulletHeader">
         <source>Use it as a private browser:</source>
         <target>Gebruik als een privébrowser:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowHelp" xml:space="preserve">
+      <trans-unit id="About.rowHelp">
         <source>Help</source>
         <target>Help</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowPrivacy" xml:space="preserve">
+      <trans-unit id="About.rowPrivacy">
         <source>Privacy Notice</source>
         <target>Privacyverklaring</target>
         <note>Link to Privacy Notice in the About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowRights" xml:space="preserve">
+      <trans-unit id="About.rowRights">
         <source>Your Rights</source>
         <target>Uw rechten</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet1" xml:space="preserve">
+      <trans-unit id="About.safariBullet1">
         <source>Block trackers for improved privacy</source>
         <target>Trackers blokkeren voor verbeterde privacy</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet2" xml:space="preserve">
+      <trans-unit id="About.safariBullet2">
         <source>Block web fonts to reduce page size</source>
         <target>Weblettertypen blokkeren om paginagrootte te verminderen</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBulletHeader" xml:space="preserve">
+      <trans-unit id="About.safariBulletHeader">
         <source>Use it as a Safari extension:</source>
         <target>Gebruik als een Safari-extensie:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.title" xml:space="preserve">
+      <trans-unit id="About.title">
         <source>About %@</source>
         <target>Over %@</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, takes the user to a page with information about the product. Also displayed as a header for the About page.</note>
       </trans-unit>
-      <trans-unit id="About.topLabel" xml:space="preserve">
+      <trans-unit id="About.topLabel">
         <source>%@ puts you in control.</source>
         <target>%@ geeft u de controle.</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Dismiss" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Dismiss">
         <source>Ok</source>
         <target>OK</target>
         <note>Button to dismiss the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Message" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Message">
         <source>An error occured while adding the pass to Wallet. Please try again later.</source>
         <target>Er is een fout opgetreden bij het toevoegen van de kaart aan Wallet. Probeer het later opnieuw.</target>
         <note>Message of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Title" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Title">
         <source>Failed to Add Pass</source>
         <target>Kaart toevoegen mislukt</target>
         <note>Title of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="Authentication.reason" xml:space="preserve">
+      <trans-unit id="Authentication.reason">
         <source>Authenticate to return to %@</source>
         <target>Authenticeer om naar %@ terug te keren</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID, Face ID, or passcode to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrl">
         <source>Add Custom URL</source>
         <target>Aangepaste URL toevoegen</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlError" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlError">
         <source>Double-check the URL you entered.</source>
         <target>Controleer de ingevoerde URL.</target>
         <note>Label for error state when entering an invalid URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlExample" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlExample">
         <source>Example: example.com</source>
         <target>Voorbeeld: example.com</target>
         <note>A label displaying an example URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlLabel">
         <source>URL to add</source>
         <target>Toe te voegen URL</target>
         <note>Label for the input to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlPlaceholder" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlPlaceholder">
         <source>Paste or enter URL</source>
         <target>Plak of voer URL in</target>
         <note>Placeholder for the input field to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlWithPlus" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlWithPlus">
         <source>+ Add Custom URL</source>
         <target>+ Aangepaste URL toevoegen</target>
         <note>Label for button to add a custom URL with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.customDescriptoin">
         <source>Add and manage custom autocomplete URLs.</source>
         <target>Eigen URL’s voor automatisch aanvullen toevoegen en beheren</target>
         <note>Description for adding and managing custom autocomplete URLs</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.customLabel">
         <source>Custom URLs</source>
         <target>Aangepaste URL’s</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.customTitle">
         <source>CUSTOM URL LIST</source>
         <target>LIJST VAN AANGEPASTE URL’S</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customUrlAdded" xml:space="preserve">
+      <trans-unit id="Autocomplete.customUrlAdded">
         <source>New Custom URL added.</source>
         <target>Nieuwe aangepaste URL toegevoegd.</target>
         <note>Label for toast alerting a custom URL has been added</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultDescriptoin">
         <source>Enable to have %@ autocomplete over 450 popular URLs in the address bar.</source>
         <target>Schakel dit in om %@ automatisch meer dan 450 populaire URL’s in de adresbalk te laten aanvullen.</target>
         <note>Description for enabling or disabling the default list. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultLabel">
         <source>Autocomplete</source>
         <target>Automatisch aanvullen</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultTitle">
         <source>DEFAULT URL LIST</source>
         <target>LIJST VAN STANDAARD-URL’S</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.disabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.disabled">
         <source>Disabled</source>
         <target>Uitgeschakeld</target>
         <note>label describing URL Autocomplete as disabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.duplicateUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.duplicateUrl">
         <source>URL already exists</source>
         <target>URL bestaat al</target>
         <note>Label for toast alerting that the custom URL being added is a duplicate</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.emptyState" xml:space="preserve">
+      <trans-unit id="Autocomplete.emptyState">
         <source>No Custom URLs to display</source>
         <target>Geen aangepaste URL’s om weer te geven</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.enabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.enabled">
         <source>Enabled</source>
         <target>Ingeschakeld</target>
         <note>label describing URL Autocomplete as enabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.manageSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.manageSites">
         <source>Manage Sites</source>
         <target>Websites beheren</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySites" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySites">
         <source>My Sites</source>
         <target>Mijn websites</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySitesDesc" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySitesDesc">
         <source>Enable to have %@ autocomplete your favorite URLs.</source>
         <target>Schakel dit in om %@ automatisch uw favoriete URL’s te laten aanvullen.</target>
         <note>Description for adding and managing custom autocomplete URLs. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.topSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.topSites">
         <source>Top Sites</source>
         <target>Topwebsites</target>
         <note>Label for enabling or disabling top sites</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.newSession" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.newSession">
         <source>New Session</source>
         <target>Nieuwe sessie</target>
         <note>Create a new session after failing a biometric check</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.reason" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.reason">
         <source>Unlock %@ when re-opening in order to prevent unauthorized access.</source>
         <target>%@ ontgrendelen bij opnieuw openen om ongeautoriseerde toegang te voorkomen.</target>
         <note>%@ is app name. Explanation for why the app needs access to biometric information. Prompt is only shown once when the user first tries to enable Face ID to open the app.</note>
       </trans-unit>
-      <trans-unit id="Browser.backLabel" xml:space="preserve">
+      <trans-unit id="Browser.backLabel">
         <source>Back</source>
         <target>Terug</target>
         <note>Accessibility label for the back button</note>
       </trans-unit>
-      <trans-unit id="Browser.copyAddressLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyAddressLabel">
         <source>Copy Address</source>
         <target>Adres kopiëren</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.copyMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyMenuLabel">
         <source>Copy</source>
         <target>Kopiëren</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.customURLMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.customURLMenuLabel">
         <source>Add Custom URL</source>
         <target>Aangepaste URL toevoegen</target>
         <note>Custom URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.forwardLabel" xml:space="preserve">
+      <trans-unit id="Browser.forwardLabel">
         <source>Forward</source>
         <target>Vooruit</target>
         <note>Accessibility label for the forward button</note>
       </trans-unit>
-      <trans-unit id="Browser.reloadLabel" xml:space="preserve">
+      <trans-unit id="Browser.reloadLabel">
         <source>Reload</source>
         <target>Opnieuw laden</target>
         <note>Accessibility label for the reload button</note>
       </trans-unit>
-      <trans-unit id="Browser.settingsLabel" xml:space="preserve">
+      <trans-unit id="Browser.settingsLabel">
         <source>Settings</source>
         <target>Instellingen</target>
         <note>Accessibility label for the settings button</note>
       </trans-unit>
-      <trans-unit id="Browser.shareLabel" xml:space="preserve">
+      <trans-unit id="Browser.shareLabel">
         <source>Share</source>
         <target>Delen</target>
         <note>Accessibility label for the share button</note>
       </trans-unit>
-      <trans-unit id="Browser.stopLabel" xml:space="preserve">
+      <trans-unit id="Browser.stopLabel">
         <source>Stop</source>
         <target>Stoppen</target>
         <note>Accessibility label for the stop button</note>
       </trans-unit>
-      <trans-unit id="Cancel" xml:space="preserve">
+      <trans-unit id="Cancel">
         <source>Cancel</source>
         <target>Annuleren</target>
         <note>Label on button to cancel edits</note>
       </trans-unit>
-      <trans-unit id="Done" xml:space="preserve">
+      <trans-unit id="Done">
         <source>Done</source>
         <target>Gereed</target>
         <note>Label on button to complete edits</note>
       </trans-unit>
-      <trans-unit id="Edit" xml:space="preserve">
+      <trans-unit id="Edit">
         <source>Edit</source>
         <target>Bewerken</target>
         <note>Label on button to allow edits</note>
       </trans-unit>
-      <trans-unit id="Error.tryAgainButton" xml:space="preserve">
+      <trans-unit id="Error.tryAgainButton">
         <source>Try again</source>
         <target>Opnieuw proberen</target>
         <note>Button label to reload the error page</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.cancelTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.cancelTitle">
         <source>Cancel</source>
         <target>Annuleren</target>
         <note>Button label used for cancelling to open another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.messageTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.messageTitle">
         <source>%@ wants to open another App</source>
         <target>%@ wil een andere app openen</target>
         <note>Dialog title used for opening an external app from Focus. The placeholder string is the app name of either Focus or Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.openTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.openTitle">
         <source>Open</source>
         <target>Openen</target>
         <note>Button label for opening another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.callButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.callButton">
         <source>Call</source>
         <target>Bellen</target>
         <note>Button label in tel: dialog to call a phone number. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.cancelButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.cancelButton">
         <source>Cancel</source>
         <target>Annuleren</target>
         <note>Button label in external link dialog to cancel the dialog. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.emailButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.emailButton">
         <source>Email</source>
         <target>E-mailen</target>
         <note>Button label in mailto: dialog to send an email. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.messageTitleWithPlaceholder" xml:space="preserve">
+      <trans-unit id="ExternalLink.messageTitleWithPlaceholder">
         <source>You are now leaving %@.</source>
         <target>U verlaat nu %@.</target>
         <note>Dialog title used for Maps/App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreButton">
         <source>Open App Store</source>
         <target>App Store openen</target>
         <note>Button label in App Store URL dialog to open the App Store. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreTitle" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreTitle">
         <source>%@ wants to open the App Store.</source>
         <target>%@ wil de App Store openen.</target>
         <note>Dialog title used to open App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openMapsButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openMapsButton">
         <source>Open Maps</source>
         <target>Maps openen</target>
         <note>Button label in Maps URL dialog to open Maps. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="FindInPage.Done" xml:space="preserve">
+      <trans-unit id="FindInPage.Done">
         <source>Find in page done</source>
         <target>Zoeken op pagina gereed</target>
         <note>Accessibility label for done button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.NextResult" xml:space="preserve">
+      <trans-unit id="FindInPage.NextResult">
         <source>Find next in page</source>
         <target>Volgende zoeken op pagina</target>
         <note>Accessibility label for next result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.PreviousResult" xml:space="preserve">
+      <trans-unit id="FindInPage.PreviousResult">
         <source>Find previous in page</source>
         <target>Vorige zoeken op pagina</target>
         <note>Accessibility label for previous result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FirstRun.lastSlide.buttonLabel" xml:space="preserve">
+      <trans-unit id="FirstRun.lastSlide.buttonLabel">
         <source>OK, Got It!</source>
         <target>OK, begrepen!</target>
         <note>Label on button to dismiss first run UI</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelDescription" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelDescription">
         <source>Automatically block online trackers while you browse. Then tap to erase visited pages, searches, cookies and passwords from your device.</source>
         <target>Blokkeer automatisch onlinetrackers terwijl u surft. Tik daarna om bezochte pagina’s, zoekopdrachten, cookies en wachtwoorden op uw apparaat te wissen.</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelTagline" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelTagline">
         <source>Browse like no one’s watching.</source>
         <target>Surf alsof niemand meekijkt.</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="Focus.handoffSyncing" xml:space="preserve">
+      <trans-unit id="Focus.handoffSyncing">
         <source>Apple Handoff is syncing</source>
         <target>Synchroniseren met Apple Handoff</target>
         <note>Title for the loading screen when the handoff of clipboard delays Focus launch. “Handoff” should not be localized, see https://support.apple.com/HT204681</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel1" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel1">
         <source>Automatic private browsing.</source>
         <target>Automatische privénavigatie.</target>
         <note>First label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel2" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel2">
         <source>Browse. Erase. Repeat.</source>
         <target>Surfen. Wissen. Herhalen.</target>
         <note>Second label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Menu.Close" xml:space="preserve">
+      <trans-unit id="Menu.Close">
         <source>Close</source>
         <target>Sluiten</target>
         <note>Button label used to close a menu that displays as a popup.</note>
       </trans-unit>
-      <trans-unit id="Open.Cancel" xml:space="preserve">
+      <trans-unit id="Open.Cancel">
         <source>Cancel</source>
         <target>Annuleren</target>
         <note>Label in share alert to cancel the alert</note>
       </trans-unit>
-      <trans-unit id="Open.Firefox" xml:space="preserve">
+      <trans-unit id="Open.Firefox">
         <source>Firefox (Private Browsing)</source>
         <target>Firefox (Privénavigatie)</target>
         <note>Label in share alert to open the URL in Firefox</note>
       </trans-unit>
-      <trans-unit id="Open.More" xml:space="preserve">
+      <trans-unit id="Open.More">
         <source>More</source>
         <target>Meer</target>
         <note>Label in share alert to open the full system share menu</note>
       </trans-unit>
-      <trans-unit id="Open.Safari" xml:space="preserve">
+      <trans-unit id="Open.Safari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Label in share alert to open the URL in Safari</note>
       </trans-unit>
-      <trans-unit id="Request Desktop Site" xml:space="preserve">
+      <trans-unit id="Request Desktop Site">
         <source>Request Desktop Site</source>
         <target>Desktop­website opvragen</target>
         <note>Label for button that requests the desktop version of the currently loaded website.</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsContentBlockers" xml:space="preserve">
+      <trans-unit id="Safari.instructionsContentBlockers">
         <source>Tap Safari, then select Content Blockers</source>
         <target>Tik op Safari en selecteer Materiaalblokkeringen</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsEnable" xml:space="preserve">
+      <trans-unit id="Safari.instructionsEnable">
         <source>Enable %@</source>
         <target>%@ inschakelen</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsNotEnabled" xml:space="preserve">
+      <trans-unit id="Safari.instructionsNotEnabled">
         <source>%@ is not enabled.</source>
         <target>%@ is niet ingeschakeld.</target>
         <note>Error label when the blocker is not enabled, shown in the intro and main app when disabled</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsOpen" xml:space="preserve">
+      <trans-unit id="Safari.instructionsOpen">
         <source>Open Settings App</source>
         <target>Instellingen openen</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Save" xml:space="preserve">
+      <trans-unit id="Save">
         <source>Save</source>
         <target>Opslaan</target>
         <note>Save button label</note>
       </trans-unit>
-      <trans-unit id="SearchEngine.addEngineError" xml:space="preserve">
+      <trans-unit id="SearchEngine.addEngineError">
         <source>That didn't work. Try replacing the search term with this: %s.</source>
         <target>Dat werkte niet. Probeer de zoekterm te vervangen door %s.</target>
         <note>Label for error state when entering an invalid search engine URL. %s is a search term in a URL.</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptDisable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptDisable">
         <source>No</source>
         <target>Nee</target>
         <note>Label for disable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptEnable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptEnable">
         <source>Yes</source>
         <target>Ja</target>
         <note>Label for enable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptMessage" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptMessage">
         <source>To get suggestions, %@ needs to send what you type in the address bar to the search engine.</source>
         <target>Om suggesties te verkrijgen, moet %@ wat u in de adresbalk intypt naar de zoekmachine sturen.</target>
         <note>%@ is the name of the app (Focus / Klar). Label for search suggestions prompt message</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptTitle" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptTitle">
         <source>Show Search Suggestions?</source>
         <target>Zoeksuggesties tonen?</target>
         <note>Title for search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButton" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButton">
         <source>Add Another Search Engine</source>
         <target>Nog een zoekmachine toevoegen</target>
         <note>Text for button to add another search engine in settings</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus">
         <source>+ Add Another Search Engine</source>
         <target>+ Nog een zoekmachine toevoegen</target>
         <note>Text for button to add another search engine in settings with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineTitle" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineTitle">
         <source>Add Search Engine</source>
         <target>Zoekmachine toevoegen</target>
         <note>Title on add search engine settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.InstalledSearchEngines" xml:space="preserve">
+      <trans-unit id="Settings.Search.InstalledSearchEngines">
         <source>INSTALLED SEARCH ENGINES</source>
         <target>GEÏNSTALLEERDE ZOEKMACHINES</target>
         <note>Header for rows of installed search engines</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NameToDisplay" xml:space="preserve">
+      <trans-unit id="Settings.Search.NameToDisplay">
         <source>Name to display</source>
         <target>Weergavenaam</target>
         <note>Label for input field for the name of the search engine to be added</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NewSearchEngineAdded" xml:space="preserve">
+      <trans-unit id="Settings.Search.NewSearchEngineAdded">
         <source>New Search Engine Added.</source>
         <target>Nieuwe zoekmachine toegevoegd.</target>
         <note>Toast displayed after adding a search engine</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.RestoreEngine" xml:space="preserve">
+      <trans-unit id="Settings.Search.RestoreEngine">
         <source>Restore Default Search Engines</source>
         <target>Standaardzoekmachines terugzetten</target>
         <note>Label for button to bring deleted default engines back</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchEngineName" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchEngineName">
         <source>Search engine name</source>
         <target>Naam van zoekmachine</target>
         <note>Placeholder text for input of new search engine name</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplate" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplate">
         <source>Search string to use</source>
         <target>Te gebruiken zoekstring</target>
         <note>Label for input of search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplatePlaceholder" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplatePlaceholder">
         <source>Paste or enter search string. If necessary, replace search term with: %s.</source>
         <target>Plak of voer de zoekstring in. Vervang zo nodig de zoekterm door %s.</target>
         <note>Placeholder text for input of new search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.autocompleteSection" xml:space="preserve">
+      <trans-unit id="Settings.autocompleteSection">
         <source>URL Autocomplete</source>
         <target>URL’s automatisch aanvullen</target>
         <note>Title for the URL Autocomplete row</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherMessage" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherMessage">
         <source>Blocking other content trackers may break some videos and web pages.</source>
         <target>Blokkeren van andere inhoudstrackers kan sommige video’s en webpagina’s verstoren.</target>
         <note>Alert message shown when toggling the Content blocker</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherNo2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherNo2">
         <source>Cancel</source>
         <target>Annuleren</target>
         <note>Button label for declining Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherYes2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherYes2">
         <source>Block Content Trackers</source>
         <target>Inhoudstrackers blokkeren</target>
         <note>Button label for accepting Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSearchSuggestion" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSearchSuggestion">
         <source>%@ will send what you type in the address bar to your search engine.</source>
         <target>%@ zal wat u in de adresbalk intypt naar uw zoekmachine sturen.</target>
         <note>Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSendUsageData">
         <source>Mozilla strives to collect only what we need to provide and improve %@ for everyone.</source>
         <target>Mozilla streeft ernaar alleen te verzamelen wat nodig is om %@ voor iedereen aan te bieden en te verbeteren.</target>
         <note>Description associated to the Send Usage Data toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.learnMore" xml:space="preserve">
+      <trans-unit id="Settings.learnMore">
         <source>Learn more.</source>
         <target>Meer info</target>
         <note>Subtitle for Send Anonymous Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.rate" xml:space="preserve">
+      <trans-unit id="Settings.rate">
         <source>Rate %@</source>
         <target>%@ waarderen</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, allows the user to leave a review for the app on the app store.</note>
       </trans-unit>
-      <trans-unit id="Settings.safariTitle" xml:space="preserve">
+      <trans-unit id="Settings.safariTitle">
         <source>SAFARI INTEGRATION</source>
         <target>SAFARI-INTEGRATIE</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.screenTitle" xml:space="preserve">
+      <trans-unit id="Settings.screenTitle">
         <source>Settings</source>
         <target>Instellingen</target>
         <note>Title for settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchLabel" xml:space="preserve">
+      <trans-unit id="Settings.searchLabel">
         <source>Search Engine</source>
         <target>Zoekmachine</target>
         <note>Label for the search engine in the search screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchSuggestions" xml:space="preserve">
+      <trans-unit id="Settings.searchSuggestions">
         <source>Get Search Suggestions</source>
         <target>Zoeksuggesties verkrijgen</target>
         <note>Label for the Search Suggestions toggle row</note>
       </trans-unit>
-      <trans-unit id="Settings.searchTitle2" xml:space="preserve">
+      <trans-unit id="Settings.searchTitle2">
         <source>SEARCH</source>
         <target>ZOEKEN</target>
         <note>Title for the search selection screen</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionIntegration" xml:space="preserve">
+      <trans-unit id="Settings.sectionIntegration">
         <source>INTEGRATION</source>
         <target>INTEGRATIE</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionMozilla" xml:space="preserve">
+      <trans-unit id="Settings.sectionMozilla">
         <source>MOZILLA</source>
         <target>MOZILLA</target>
         <note>Section label for Mozilla toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPerformance" xml:space="preserve">
+      <trans-unit id="Settings.sectionPerformance">
         <source>PERFORMANCE</source>
         <target>PRESTATIES</target>
         <note>Section label for performance toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPrivacy" xml:space="preserve">
+      <trans-unit id="Settings.sectionPrivacy">
         <source>PRIVACY</source>
         <target>PRIVACY</target>
         <note>Section label for privacy toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionSecurity" xml:space="preserve">
+      <trans-unit id="Settings.sectionSecurity">
         <source>SECURITY</source>
         <target>BEVEILIGING</target>
         <note>Header label for security toggles displayed in the settings menu</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAds2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAds2">
         <source>Advertising</source>
         <target>Advertenties</target>
         <note>Label for the checkbox to toggle Advertising trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAnalytics2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAnalytics2">
         <source>Analytics</source>
         <target>Analyse</target>
         <note>Label for the checkbox to toggle Analytics trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockFonts" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockFonts">
         <source>Block web fonts</source>
         <target>Weblettertypen blokkeren</target>
         <note>Label for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockOther2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockOther2">
         <source>Content</source>
         <target>Inhoud</target>
         <note>Label for the checkbox to toggle Other trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockSocial2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockSocial2">
         <source>Social</source>
         <target>Sociaal</target>
         <note>Label for the checkbox to toggle Social trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceID" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceID">
         <source>Use Face ID to unlock app</source>
         <target>Face ID voor ontgrendelen van app gebruiken</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceIDDescription">
         <source>Face ID can unlock %@ if a URL is already open in the app</source>
         <target>Face ID kan %@ ontgrendelen als een URL al in de app is geopend</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Face ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleHomeScreenTips" xml:space="preserve">
+      <trans-unit id="Settings.toggleHomeScreenTips">
         <source>Show home screen tips</source>
         <target>Tips op startscherm tonen</target>
         <note>Show home screen tips toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleOtherSubtitle" xml:space="preserve">
+      <trans-unit id="Settings.toggleOtherSubtitle">
         <source>May break some videos and Web pages</source>
         <target>Kan sommige video’s en webpagina’s verstoren</target>
         <note>Label subtitle for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSafari" xml:space="preserve">
+      <trans-unit id="Settings.toggleSafari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Safari toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.toggleSendUsageData">
         <source>Send usage data</source>
         <target>Gebruiksgegevens verzenden</target>
         <note>Label for Send Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchID" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchID">
         <source>Use Touch ID to unlock app</source>
         <target>Touch ID voor ontgrendelen van app gebruiken</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchIDDescription">
         <source>Touch ID can unlock %@ if a URL is already open in the app</source>
         <target>Touch ID kan %@ ontgrendelen als een URL al in de app is geopend</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Touch ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOff" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOff">
         <source>Off</source>
         <target>Uit</target>
         <note>Status off for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOn" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOn">
         <source>On</source>
         <target>Aan</target>
         <note>Status on for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.whatsNewTitle" xml:space="preserve">
+      <trans-unit id="Settings.whatsNewTitle">
         <source>What’s New</source>
         <target>Wat is er nieuw</target>
         <note>Title for What's new screen</note>
       </trans-unit>
-      <trans-unit id="Settinsg.siriShortcutsTitle" xml:space="preserve">
+      <trans-unit id="Settinsg.siriShortcutsTitle">
         <source>SIRI SHORTCUTS</source>
         <target>SIRI-SNELKOPPELINGEN</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.FindInPage" xml:space="preserve">
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Zoeken op pagina</target>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.GetFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.GetFirefox">
         <source>Get the Firefox App</source>
         <target>Firefox downloaden</target>
         <note>Text for the share menu option when a user wants to open a page in Firefox but doesn’t have it installed. This string will not wrap in the interface. Instead, it will truncate. To prevent this, please keep the localized string to 18 or fewer characters. If your string runs longer than 18 characters, you can use 'Get Firefox' as the basis for your string. However, if at all possible, we’d like to signal to the user that they will be going to the App Store and installing the application from there. That is why we are using Get and App in the en-US string.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.PageActions" xml:space="preserve">
+      <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <target>Pagina-acties</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestDesktop" xml:space="preserve">
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
         <target>Desktop­website opvragen</target>
         <note>Text for the share menu option when a user wants to reload the site as a desktop</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestMobile" xml:space="preserve">
+      <trans-unit id="ShareMenu.RequestMobile">
         <source>Request Mobile Site</source>
         <target>Mobiele website opvragen</target>
         <note>Text for the share menu option when a user wants to reload the site as a mobile device</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenChrome" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenChrome">
         <source>Open in Chrome</source>
         <target>Openen in Chrome</target>
         <note>Text for the share menu option when a user wants to open the current website in the Chrome app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenFirefox">
         <source>Open in Firefox</source>
         <target>Openen in Firefox</target>
         <note>Text for the share menu option when a user wants to open the current website in the Firefox app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenSafari" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenSafari">
         <source>Open in Safari</source>
         <target>Openen in Safari</target>
         <note>Text for the share menu option when a user wants to open the current website in the Safari app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.SharePage" xml:space="preserve">
+      <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <target>Pagina delen met…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
       </trans-unit>
-      <trans-unit id="Siri.add" xml:space="preserve">
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
+      </trans-unit>
+      <trans-unit id="Siri.add">
         <source>Add</source>
         <target>Toevoegen</target>
         <note>Button to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.addTo" xml:space="preserve">
+      <trans-unit id="Siri.addTo">
         <source>Add to Siri</source>
         <target>Toevoegen aan Siri</target>
         <note>Button to add a specified shortcut option to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.editOpenUrl" xml:space="preserve">
+      <trans-unit id="Siri.editOpenUrl">
         <source>Re-Record or Delete Shortcut</source>
         <target>Snelkoppeling opnieuw vastleggen of verwijderen</target>
         <note>Label for button to edit the Siri phrase or delete the Siri functionality.</note>
       </trans-unit>
-      <trans-unit id="Siri.erase" xml:space="preserve">
+      <trans-unit id="Siri.erase">
         <source>Erase</source>
         <target>Wissen</target>
         <note>Title of option in settings to set up Siri to erase</note>
       </trans-unit>
-      <trans-unit id="Siri.eraseAndOpen" xml:space="preserve">
+      <trans-unit id="Siri.eraseAndOpen">
         <source>Erase &amp; Open</source>
         <target>Wissen en openen</target>
         <note>Title of option in settings to set up Siri to erase and then open the app.</note>
       </trans-unit>
-      <trans-unit id="Siri.favoriteUrl" xml:space="preserve">
+      <trans-unit id="Siri.favoriteUrl">
         <source>Open Favorite Site</source>
         <target>Favoriete website openen</target>
         <note>Title for screen to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.openURL" xml:space="preserve">
+      <trans-unit id="Siri.openURL">
         <source>Open Favorite Site</source>
         <target>Favoriete website openen</target>
         <note>Title of option in settings to set up Siri to open a specified URL in Focus/Klar.</note>
       </trans-unit>
-      <trans-unit id="Siri.urlToOpen" xml:space="preserve">
+      <trans-unit id="Siri.urlToOpen">
         <source>URL to open</source>
         <target>Te openen URL</target>
         <note>Label for input to set a favorite URL to be opened by Siri.</note>
       </trans-unit>
-      <trans-unit id="URL.addToAutocompleteLabel" xml:space="preserve">
+      <trans-unit id="URL.addToAutocompleteLabel">
         <source>Add link to autocomplete</source>
         <target>Koppeling naar automatisch aanvullen toevoegen</target>
         <note>Label displayed for button used as a shortcut to add a link to the list of URLs to autocomplete.</note>
       </trans-unit>
-      <trans-unit id="URL.cancelLabel" xml:space="preserve">
+      <trans-unit id="URL.cancelLabel">
         <source>Cancel</source>
         <target>Annuleren</target>
         <note>Label for cancel button shown when entering a URL or search</note>
       </trans-unit>
-      <trans-unit id="URL.contextMenu" xml:space="preserve">
+      <trans-unit id="URL.contextMenu">
         <source>Paste &amp; Go</source>
         <target>Plakken &amp; Gaan</target>
         <note>Text for the URL context menu when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.eraseButtonLabel" xml:space="preserve">
+      <trans-unit id="URL.eraseButtonLabel">
         <source>ERASE</source>
         <target>WISSEN</target>
         <note>Erase button in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.eraseMessageLabel2" xml:space="preserve">
+      <trans-unit id="URL.eraseMessageLabel2">
         <source>Browsing history cleared</source>
         <target>Navigatiegeschiedenis gewist</target>
         <note>Message shown after pressing the Erase button</note>
       </trans-unit>
-      <trans-unit id="URL.findOnPageLabel" xml:space="preserve">
+      <trans-unit id="URL.findOnPageLabel">
         <source>Find in page: %@</source>
         <target>Zoeken op pagina: %@</target>
         <note>Label displayed for find in page button when typing in the URL Bar. %@ is any text the user has typed into the URL bar that they want to find on the current page.</note>
       </trans-unit>
-      <trans-unit id="URL.paste" xml:space="preserve">
+      <trans-unit id="URL.paste">
         <source>Paste</source>
         <target>Plakken</target>
         <note>Text for a menu displayed from the bottom of the screen when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.placeholderText" xml:space="preserve">
+      <trans-unit id="URL.placeholderText">
         <source>Search or enter address</source>
         <target>Voer zoekterm of adres in</target>
         <note>Placeholder text shown in the URL bar before the user navigates to a page</note>
       </trans-unit>
-      <trans-unit id="URL.searchLabel" xml:space="preserve">
+      <trans-unit id="URL.searchLabel">
         <source>Search for %@</source>
         <target>Zoeken naar %@</target>
         <note>Label displayed for search button when typing in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="URL.trackersBlockedLabel">
         <source>Trackers blocked</source>
         <target>Trackers geblokkeerd</target>
         <note>Text for the URL bar showing the number of trackers blocked on a webpage.</note>
       </trans-unit>
-      <trans-unit id="actionSheet.openIn" xml:space="preserve">
+      <trans-unit id="actionSheet.openIn">
         <source>Open in %@</source>
         <target>Openen in %@</target>
         <note>Title for action sheet item to open the current page in another application. Placeholder is the name of the application to open the current page.</note>
       </trans-unit>
-      <trans-unit id="browser.copyAddressToast" xml:space="preserve">
+      <trans-unit id="browser.copyAddressToast">
         <source>URL Copied To Clipboard</source>
         <target>URL naar klembord gekopieerd</target>
         <note>Toast displayed after a URL has been copied to the clipboard</note>
       </trans-unit>
-      <trans-unit id="browserShortcutDescription.selectLocationBar" xml:space="preserve">
+      <trans-unit id="browserShortcutDescription.selectLocationBar">
         <source>Select Location Bar</source>
         <target>Locatiebalk selecteren</target>
         <note>Label to display in the Discoverability overlay for keyboard shortcuts</note>
       </trans-unit>
-      <trans-unit id="contextMenu.clipboardLink" xml:space="preserve">
+      <trans-unit id="contextMenu.clipboardLink">
         <source>Link you copied: %@</source>
         <target>Gekopieerde koppeling: %@</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.copyImageTitle">
         <source>Copy Image</source>
         <target>Afbeelding kopiëren</target>
         <note>Text for the context menu when a user wants to copy an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyLink" xml:space="preserve">
+      <trans-unit id="contextMenu.copyLink">
         <source>Copy Link</source>
         <target>Koppeling kopiëren</target>
         <note>Text for the context menu when a user wants to copy a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.linkCopied" xml:space="preserve">
+      <trans-unit id="contextMenu.linkCopied">
         <source>Link you copied: </source>
         <target>Gekopieerde koppeling:</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.saveImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.saveImageTitle">
         <source>Save Image</source>
         <target>Afbeelding opslaan</target>
         <note>Text for the context menu when a user wants to save an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.shareLinkTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.shareLinkTitle">
         <source>Share Link</source>
         <target>Koppeling delen</target>
         <note>Text for the context menu when a user wants to share a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="externalAppLinkWithAppName.messageTitle" xml:space="preserve">
+      <trans-unit id="externalAppLinkWithAppName.messageTitle">
         <source>%1$@ wants to open %2$@</source>
         <target>%1$@ wil %2$@ openen</target>
         <note>Dialog title used for opening an external app from Focus. First placeholder string is the app name of either Focus or Klar and the second placeholder string specifies the app it wants to open.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.description" xml:space="preserve">
+      <trans-unit id="photosPermission.description">
         <source>This lets you save images to your Camera Roll</source>
         <target>Hiermee kunt u afbeeldingen opslaan naar uw Filmrol</target>
         <note>Description for dialog used for requesting a user to enable access to Photos.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.openSettings" xml:space="preserve">
+      <trans-unit id="photosPermission.openSettings">
         <source>Open Settings</source>
         <target>Instellingen openen</target>
         <note>Title for button that takes the user to system settings</note>
       </trans-unit>
-      <trans-unit id="photosPermission.title" xml:space="preserve">
+      <trans-unit id="photosPermission.title">
         <source>“%@” Would Like to Access Your Photos</source>
         <target>‘%@’ vraagt om toegang tot uw foto’s</target>
         <note>Dialog title used for requesting a user to enable access to Photos. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="settings.Search.SearchTemplateExample" xml:space="preserve">
+      <trans-unit id="settings.Search.SearchTemplateExample">
         <source>Example: searchengineexample.com/search/?q=%s</source>
         <target>Voorbeeld: searchengineexample.com/search/?q=%s</target>
         <note>Text displayed as an example of the template to add a search engine.</note>
       </trans-unit>
-      <trans-unit id="share" xml:space="preserve">
+      <trans-unit id="share">
         <source>Share</source>
         <target>Delen</target>
         <note>Text for a share button</note>
       </trans-unit>
-      <trans-unit id="shareMenu.copyAddress" xml:space="preserve">
+      <trans-unit id="shareMenu.copyAddress">
         <source>Copy Address</source>
         <target>Adres kopiëren</target>
         <note>Text for the share menu when a user wants to copy a URL.</note>
       </trans-unit>
-      <trans-unit id="touchId.reason" xml:space="preserve">
+      <trans-unit id="touchId.reason">
         <source>Use Touch ID to return to %@</source>
         <target>Gebruik Touch ID om naar %@ terug te keren</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.adTrackersLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.adTrackersLabel">
         <source>Ad trackers</source>
         <target>Advertentietrackers</target>
         <note>Label for ad trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.analyticTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.analyticTrackerLabel">
         <source>Analytic trackers</source>
         <target>Analysetrackers</target>
         <note>label for analytic trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.contentTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>
         <target>Inhoudstrackers</target>
         <note>label for content trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.disabledLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.disabledLabel">
         <source>Tracking Protection off</source>
         <target>Bescherming tegen volgen uitgeschakeld</target>
         <note>text showing the tracking protection is disabled.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.label" xml:space="preserve">
+      <trans-unit id="trackingProtection.label">
         <source>Tracking Protection</source>
         <target>Bescherming tegen volgen</target>
         <note>Title for the tracking settings page to change what trackers are blocked.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.labelDescription" xml:space="preserve">
+      <trans-unit id="trackingProtection.labelDescription">
         <source>Turning this off may fix some site problems</source>
         <target>Uitschakelen hiervan kan bepaalde websiteproblemen verhelpen</target>
         <note>Description/subtitle for the tracking protection label.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.learnMore" xml:space="preserve">
+      <trans-unit id="trackingProtection.learnMore">
         <source>Learn More</source>
         <target>Meer info</target>
         <note>Text for the button to learn more about Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.moreSettings" xml:space="preserve">
+      <trans-unit id="trackingProtection.moreSettings">
         <source>More Settings</source>
         <target>Meer instellingen</target>
         <note>Text for the button that closes the Shield Data and opens the regular Settings screen.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.socialTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.socialTrackerLabel">
         <source>Social trackers</source>
         <target>Sociale trackers</target>
         <note>label for social trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOff" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOff">
         <source>Protections are OFF for this session</source>
         <target>Beschermingen voor deze sessie staan UIT</target>
         <note>Text for the status off from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOn" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOn">
         <source>Protections are ON for this session</source>
         <target>Beschermingen voor deze sessie staan AAN</target>
         <note>Text for the status on from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleDescription1" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleDescription1">
         <source>Disable until you close %@ or tap ERASE.</source>
         <target>Uitschakelen totdat u %@ sluit of op WISSEN tikt.</target>
         <note>Description for the tracking protection toggle. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleLabel2">
         <source>Enhanced Tracking Protection</source>
         <target>Verbeterde bescherming tegen volgen</target>
         <note>Text for the toggle that enables/disables tracking protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackerDescriptionLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackerDescriptionLabel2">
         <source>Keep your data to yourself. %@ protects you from many of the most common trackers that follow what you do online.</source>
         <target>Houd uw gegevens voor uzelf. %@ beschermt u tegen veel van de meest voorkomende trackers die volgen wat u online doet.</target>
         <note>General description of tracking protection settings, which is displayed underneath the trackers preferences in Settings. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersBlockedLabel">
         <source>Trackers blocked since %@</source>
         <target>Trackers geblokkeerd sinds %@</target>
         <note>Text for tracking protection screen showing the number of trackers blocked since the app install. The placeholder is replaced with the install date of the application.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersHeader" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersHeader">
         <source>Trackers and scripts to block</source>
         <target>Te blokkeren trackers en scripts</target>
         <note>Text for the header of trackers section from Tracking Protection.</note>
@@ -1078,7 +1097,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="SettingsBundle.Licenses" xml:space="preserve">
+      <trans-unit id="SettingsBundle.Licenses">
         <source>Licenses</source>
         <target>Licenties</target>
         <note>The title of the Licenses setting in the settings that Focus shows in the global iOS Settings app.</note>
@@ -1086,3 +1105,4 @@
     </body>
   </file>
 </xliff>
+

--- a/nn-NO/focus-ios.xliff
+++ b/nn-NO/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>SIRI-SNARVEGAR</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Søk på sida</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>Sidehandlingar</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>Del sida med…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>Analyse-sporfølgjarar</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/pl/focus-ios.xliff
+++ b/pl/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>Skróty Siri</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Znajdź na stronie</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>Interakcje</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>Udostępnij stronę…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>Śledzące statystyki</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/pt-BR/focus-ios.xliff
+++ b/pt-BR/focus-ios.xliff
@@ -1,36 +1,35 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Blockzilla/en.lproj/InfoPlist.strings" source-language="en" target-language="pt-BR" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="NSCameraUsageDescription" xml:space="preserve">
+      <trans-unit id="NSCameraUsageDescription">
         <source>This lets you take and upload photos.</source>
         <target>Isso permite tirar fotos e enviá-las.</target>
         <note>Privacy - Camera Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSFaceIDUsageDescription" xml:space="preserve">
+      <trans-unit id="NSFaceIDUsageDescription">
         <source>This lets you unlock the app.</source>
         <target>Isso permite você desbloquear o aplicativo.</target>
         <note>Privacy - Face ID Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSLocationWhenInUseUsageDescription" xml:space="preserve">
+      <trans-unit id="NSLocationWhenInUseUsageDescription">
         <source>Websites you visit may request your location.</source>
         <target>Os sites que visita podem solicitar a sua localização.</target>
         <note>Privacy - Location When In Use Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSMicrophoneUsageDescription" xml:space="preserve">
+      <trans-unit id="NSMicrophoneUsageDescription">
         <source>This lets you take and upload videos.</source>
         <target>Isto lhe permite fazer e enviar vídeos.</target>
         <note>Privacy - Microphone Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSPhotoLibraryAddUsageDescription" xml:space="preserve">
+      <trans-unit id="NSPhotoLibraryAddUsageDescription">
         <source>This lets you save and upload photos.</source>
         <target>Isto lhe permite salvar e enviar fotos.</target>
         <note>Privacy - Photo Library Additions Usage Description</note>
       </trans-unit>
-      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen" xml:space="preserve">
+      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen">
         <source>Erase and Open</source>
         <target>Apagar e abrir</target>
         <note>This is the menu item that appears when you long press the Focus icon on the phone home screen.</note>
@@ -42,7 +41,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intents.Erase.Title" xml:space="preserve">
+      <trans-unit id="Intents.Erase.Title">
         <source>Erase</source>
         <target>Apagar</target>
         <note>Title of the Erase intent.</note>
@@ -54,42 +53,42 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intro.Slides.History.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Description">
         <source>Clear your entire browsing session history, passwords, cookies anytime with a single tap.</source>
         <target>Limpe todo o seu histórico de navegação, senhas e cookies a qualquer momento, com um simples toque.</target>
         <note>Description for the 'History' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.History.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Title">
         <source>Your history is history</source>
         <target>O seu histórico é história</target>
         <note>Title for the third  panel 'History' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Next.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Next.Button">
         <source>Next</source>
         <target>Próximo</target>
         <note>Button to go to the next card in Focus onboarding.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Description">
         <source>Searching for something different? Choose a different search engine.</source>
         <target>Procurando algo diferente? Escolha um mecanismo de pesquisa diferente.</target>
         <note>Description for the 'Favorite Search Engine' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Title">
         <source>Your search, your way</source>
         <target>Pesquise à sua maneira</target>
         <note>Title for the second  panel 'Search' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Skip.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Skip.Button">
         <source>Skip</source>
         <target>Pular</target>
         <note>Button to skip onboarding in Focus</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Description">
         <source>Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times.</source>
         <target>Leve a navegação privativa ao próximo nível. Bloqueie propagandas e outros conteúdos que podem rastrear você entre os sites e diminuir o tempo de carregamento das páginas.</target>
         <note>Description for the 'Welcome' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Title">
         <source>Power up your privacy</source>
         <target>Potencialize sua privacidade</target>
         <note>Title for the first panel 'Welcome' in the First Run tour.</note>
@@ -101,972 +100,992 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="About.learnMoreButton" xml:space="preserve">
+      <trans-unit id="About.learnMoreButton">
         <source>Learn more</source>
         <target>Saiba mais</target>
         <note>Button on About screen</note>
       </trans-unit>
-      <trans-unit id="About.missionLabel" xml:space="preserve">
+      <trans-unit id="About.missionLabel">
         <source>%@ is produced by Mozilla. Our mission is to foster a healthy, open Internet.</source>
         <target>O %@ é produzido pela Mozilla. Nossa missão é promover uma Internet saudável e aberta.</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet1" xml:space="preserve">
+      <trans-unit id="About.privateBullet1">
         <source>Search and browse right in the app</source>
         <target>Pesquisar e navegar direto no aplicativo</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet2" xml:space="preserve">
+      <trans-unit id="About.privateBullet2">
         <source>Block trackers (or update settings to allow trackers)</source>
         <target>Bloquear rastreadores (ou atualizar configurações para permitir rastreadores)</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet3" xml:space="preserve">
+      <trans-unit id="About.privateBullet3">
         <source>Erase to delete cookies as well as search and browsing history</source>
         <target>Apagar para excluir cookies, bem como o histórico de pesquisa e navegação</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBulletHeader" xml:space="preserve">
+      <trans-unit id="About.privateBulletHeader">
         <source>Use it as a private browser:</source>
         <target>Usá-lo como um navegador privativo:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowHelp" xml:space="preserve">
+      <trans-unit id="About.rowHelp">
         <source>Help</source>
         <target>Ajuda</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowPrivacy" xml:space="preserve">
+      <trans-unit id="About.rowPrivacy">
         <source>Privacy Notice</source>
         <target>Aviso de privacidade</target>
         <note>Link to Privacy Notice in the About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowRights" xml:space="preserve">
+      <trans-unit id="About.rowRights">
         <source>Your Rights</source>
         <target>Seus direitos</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet1" xml:space="preserve">
+      <trans-unit id="About.safariBullet1">
         <source>Block trackers for improved privacy</source>
         <target>Bloquear rastreadores para melhorar a privacidade</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet2" xml:space="preserve">
+      <trans-unit id="About.safariBullet2">
         <source>Block web fonts to reduce page size</source>
         <target>Bloquear fontes web para reduzir o tamanho da página</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBulletHeader" xml:space="preserve">
+      <trans-unit id="About.safariBulletHeader">
         <source>Use it as a Safari extension:</source>
         <target>Usá-lo como uma extensão do Safari:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.title" xml:space="preserve">
+      <trans-unit id="About.title">
         <source>About %@</source>
         <target>Sobre o %@</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, takes the user to a page with information about the product. Also displayed as a header for the About page.</note>
       </trans-unit>
-      <trans-unit id="About.topLabel" xml:space="preserve">
+      <trans-unit id="About.topLabel">
         <source>%@ puts you in control.</source>
         <target>%@ coloca você no controle.</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Dismiss" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Dismiss">
         <source>Ok</source>
         <target>Ok</target>
         <note>Button to dismiss the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Message" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Message">
         <source>An error occured while adding the pass to Wallet. Please try again later.</source>
         <target>Ocorreu um erro ao adicionar a senha no Wallet. Tente novamente mais tarde.</target>
         <note>Message of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Title" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Title">
         <source>Failed to Add Pass</source>
         <target>Falha ao adicionar senha</target>
         <note>Title of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="Authentication.reason" xml:space="preserve">
+      <trans-unit id="Authentication.reason">
         <source>Authenticate to return to %@</source>
         <target>Faça a autenticação para retornar ao %@</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID, Face ID, or passcode to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrl">
         <source>Add Custom URL</source>
         <target>Adicionar URL personalizada</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlError" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlError">
         <source>Double-check the URL you entered.</source>
         <target>Verifique novamente a URL digitada.</target>
         <note>Label for error state when entering an invalid URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlExample" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlExample">
         <source>Example: example.com</source>
         <target>Exemplo: example.com</target>
         <note>A label displaying an example URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlLabel">
         <source>URL to add</source>
         <target>URL a adicionar</target>
         <note>Label for the input to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlPlaceholder" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlPlaceholder">
         <source>Paste or enter URL</source>
         <target>Cole ou digite a URL</target>
         <note>Placeholder for the input field to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlWithPlus" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlWithPlus">
         <source>+ Add Custom URL</source>
         <target>+ Adicionar URL personalizada</target>
         <note>Label for button to add a custom URL with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.customDescriptoin">
         <source>Add and manage custom autocomplete URLs.</source>
         <target>Adicione e gerencie URLs personalizadas de preenchimento automático.</target>
         <note>Description for adding and managing custom autocomplete URLs</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.customLabel">
         <source>Custom URLs</source>
         <target>URLs personalizadas</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.customTitle">
         <source>CUSTOM URL LIST</source>
         <target>LISTA DE URLs PERSONALIZADAS</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customUrlAdded" xml:space="preserve">
+      <trans-unit id="Autocomplete.customUrlAdded">
         <source>New Custom URL added.</source>
         <target>Nova URL personalizada adicionada.</target>
         <note>Label for toast alerting a custom URL has been added</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultDescriptoin">
         <source>Enable to have %@ autocomplete over 450 popular URLs in the address bar.</source>
         <target>Habilite o %@ para ter preenchimento automático de mais de 450 URLs populares na barra de endereços.</target>
         <note>Description for enabling or disabling the default list. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultLabel">
         <source>Autocomplete</source>
         <target>Preenchimento automático</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultTitle">
         <source>DEFAULT URL LIST</source>
         <target>LISTA DE URLs PADRÃO</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.disabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.disabled">
         <source>Disabled</source>
         <target>Desativado</target>
         <note>label describing URL Autocomplete as disabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.duplicateUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.duplicateUrl">
         <source>URL already exists</source>
         <target>A URL já existe</target>
         <note>Label for toast alerting that the custom URL being added is a duplicate</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.emptyState" xml:space="preserve">
+      <trans-unit id="Autocomplete.emptyState">
         <source>No Custom URLs to display</source>
         <target>Não há URLs personalizadas para mostrar</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.enabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.enabled">
         <source>Enabled</source>
         <target>Ativado</target>
         <note>label describing URL Autocomplete as enabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.manageSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.manageSites">
         <source>Manage Sites</source>
         <target>Gerenciar sites</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySites" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySites">
         <source>My Sites</source>
         <target>Meus sites</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySitesDesc" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySitesDesc">
         <source>Enable to have %@ autocomplete your favorite URLs.</source>
         <target>Ative para o %@ completar automaticamente suas URLs preferidas.</target>
         <note>Description for adding and managing custom autocomplete URLs. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.topSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.topSites">
         <source>Top Sites</source>
         <target>Sites preferidos</target>
         <note>Label for enabling or disabling top sites</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.newSession" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.newSession">
         <source>New Session</source>
         <target>Nova sessão</target>
         <note>Create a new session after failing a biometric check</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.reason" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.reason">
         <source>Unlock %@ when re-opening in order to prevent unauthorized access.</source>
         <target>Desbloquear %@ quando reabrir para prevenir acesso não autorizado.</target>
         <note>%@ is app name. Explanation for why the app needs access to biometric information. Prompt is only shown once when the user first tries to enable Face ID to open the app.</note>
       </trans-unit>
-      <trans-unit id="Browser.backLabel" xml:space="preserve">
+      <trans-unit id="Browser.backLabel">
         <source>Back</source>
         <target>Voltar</target>
         <note>Accessibility label for the back button</note>
       </trans-unit>
-      <trans-unit id="Browser.copyAddressLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyAddressLabel">
         <source>Copy Address</source>
         <target>Copiar endereço</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.copyMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyMenuLabel">
         <source>Copy</source>
         <target>Copiar</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.customURLMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.customURLMenuLabel">
         <source>Add Custom URL</source>
         <target>Adicionar URL personalizada</target>
         <note>Custom URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.forwardLabel" xml:space="preserve">
+      <trans-unit id="Browser.forwardLabel">
         <source>Forward</source>
         <target>Avançar</target>
         <note>Accessibility label for the forward button</note>
       </trans-unit>
-      <trans-unit id="Browser.reloadLabel" xml:space="preserve">
+      <trans-unit id="Browser.reloadLabel">
         <source>Reload</source>
         <target>Recarregar</target>
         <note>Accessibility label for the reload button</note>
       </trans-unit>
-      <trans-unit id="Browser.settingsLabel" xml:space="preserve">
+      <trans-unit id="Browser.settingsLabel">
         <source>Settings</source>
         <target>Configurações</target>
         <note>Accessibility label for the settings button</note>
       </trans-unit>
-      <trans-unit id="Browser.shareLabel" xml:space="preserve">
+      <trans-unit id="Browser.shareLabel">
         <source>Share</source>
         <target>Compartilhar</target>
         <note>Accessibility label for the share button</note>
       </trans-unit>
-      <trans-unit id="Browser.stopLabel" xml:space="preserve">
+      <trans-unit id="Browser.stopLabel">
         <source>Stop</source>
         <target>Parar</target>
         <note>Accessibility label for the stop button</note>
       </trans-unit>
-      <trans-unit id="Cancel" xml:space="preserve">
+      <trans-unit id="Cancel">
         <source>Cancel</source>
         <target>Cancelar</target>
         <note>Label on button to cancel edits</note>
       </trans-unit>
-      <trans-unit id="Done" xml:space="preserve">
+      <trans-unit id="Done">
         <source>Done</source>
         <target>Concluído</target>
         <note>Label on button to complete edits</note>
       </trans-unit>
-      <trans-unit id="Edit" xml:space="preserve">
+      <trans-unit id="Edit">
         <source>Edit</source>
         <target>Editar</target>
         <note>Label on button to allow edits</note>
       </trans-unit>
-      <trans-unit id="Error.tryAgainButton" xml:space="preserve">
+      <trans-unit id="Error.tryAgainButton">
         <source>Try again</source>
         <target>Tentar novamente</target>
         <note>Button label to reload the error page</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.cancelTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.cancelTitle">
         <source>Cancel</source>
         <target>Cancelar</target>
         <note>Button label used for cancelling to open another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.messageTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.messageTitle">
         <source>%@ wants to open another App</source>
         <target>%@ quer abrir outro aplicativo</target>
         <note>Dialog title used for opening an external app from Focus. The placeholder string is the app name of either Focus or Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.openTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.openTitle">
         <source>Open</source>
         <target>Abrir</target>
         <note>Button label for opening another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.callButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.callButton">
         <source>Call</source>
         <target>Chamar</target>
         <note>Button label in tel: dialog to call a phone number. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.cancelButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.cancelButton">
         <source>Cancel</source>
         <target>Cancelar</target>
         <note>Button label in external link dialog to cancel the dialog. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.emailButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.emailButton">
         <source>Email</source>
         <target>E-mail</target>
         <note>Button label in mailto: dialog to send an email. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.messageTitleWithPlaceholder" xml:space="preserve">
+      <trans-unit id="ExternalLink.messageTitleWithPlaceholder">
         <source>You are now leaving %@.</source>
         <target>Você está deixando o %@.</target>
         <note>Dialog title used for Maps/App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreButton">
         <source>Open App Store</source>
         <target>Abrir App Store</target>
         <note>Button label in App Store URL dialog to open the App Store. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreTitle" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreTitle">
         <source>%@ wants to open the App Store.</source>
         <target>%@ deseja abrir a App Store.</target>
         <note>Dialog title used to open App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openMapsButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openMapsButton">
         <source>Open Maps</source>
         <target>Abrir Maps</target>
         <note>Button label in Maps URL dialog to open Maps. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="FindInPage.Done" xml:space="preserve">
+      <trans-unit id="FindInPage.Done">
         <source>Find in page done</source>
         <target>Procurar na página concluído</target>
         <note>Accessibility label for done button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.NextResult" xml:space="preserve">
+      <trans-unit id="FindInPage.NextResult">
         <source>Find next in page</source>
         <target>Procurar próxima ocorrência na página</target>
         <note>Accessibility label for next result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.PreviousResult" xml:space="preserve">
+      <trans-unit id="FindInPage.PreviousResult">
         <source>Find previous in page</source>
         <target>Procurar ocorrência anterior na página</target>
         <note>Accessibility label for previous result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FirstRun.lastSlide.buttonLabel" xml:space="preserve">
+      <trans-unit id="FirstRun.lastSlide.buttonLabel">
         <source>OK, Got It!</source>
         <target>OK, entendi!</target>
         <note>Label on button to dismiss first run UI</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelDescription" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelDescription">
         <source>Automatically block online trackers while you browse. Then tap to erase visited pages, searches, cookies and passwords from your device.</source>
         <target>Bloqueie automaticamente os rastreadores on-line enquanto navega. Em seguida, toque para apagar páginas visitadas, pesquisas, cookies e senhas do seu dispositivo.</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelTagline" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelTagline">
         <source>Browse like no one’s watching.</source>
         <target>Navegue como se ninguém estivesse olhando.</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="Focus.handoffSyncing" xml:space="preserve">
+      <trans-unit id="Focus.handoffSyncing">
         <source>Apple Handoff is syncing</source>
         <target>O Apple Handoff está sincronizando</target>
         <note>Title for the loading screen when the handoff of clipboard delays Focus launch. “Handoff” should not be localized, see https://support.apple.com/HT204681</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel1" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel1">
         <source>Automatic private browsing.</source>
         <target>Navegação privativa automática.</target>
         <note>First label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel2" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel2">
         <source>Browse. Erase. Repeat.</source>
         <target>Navegar. Apagar. Repetir.</target>
         <note>Second label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Menu.Close" xml:space="preserve">
+      <trans-unit id="Menu.Close">
         <source>Close</source>
         <target>Fechar</target>
         <note>Button label used to close a menu that displays as a popup.</note>
       </trans-unit>
-      <trans-unit id="Open.Cancel" xml:space="preserve">
+      <trans-unit id="Open.Cancel">
         <source>Cancel</source>
         <target>Cancelar</target>
         <note>Label in share alert to cancel the alert</note>
       </trans-unit>
-      <trans-unit id="Open.Firefox" xml:space="preserve">
+      <trans-unit id="Open.Firefox">
         <source>Firefox (Private Browsing)</source>
         <target>Firefox (navegação privativa)</target>
         <note>Label in share alert to open the URL in Firefox</note>
       </trans-unit>
-      <trans-unit id="Open.More" xml:space="preserve">
+      <trans-unit id="Open.More">
         <source>More</source>
         <target>Mais</target>
         <note>Label in share alert to open the full system share menu</note>
       </trans-unit>
-      <trans-unit id="Open.Safari" xml:space="preserve">
+      <trans-unit id="Open.Safari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Label in share alert to open the URL in Safari</note>
       </trans-unit>
-      <trans-unit id="Request Desktop Site" xml:space="preserve">
+      <trans-unit id="Request Desktop Site">
         <source>Request Desktop Site</source>
         <target>Requisitar site para desktop</target>
         <note>Label for button that requests the desktop version of the currently loaded website.</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsContentBlockers" xml:space="preserve">
+      <trans-unit id="Safari.instructionsContentBlockers">
         <source>Tap Safari, then select Content Blockers</source>
         <target>Tocar em Safari e selecionar Bloqueadores de conteúdo</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsEnable" xml:space="preserve">
+      <trans-unit id="Safari.instructionsEnable">
         <source>Enable %@</source>
         <target>Ativar o %@</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsNotEnabled" xml:space="preserve">
+      <trans-unit id="Safari.instructionsNotEnabled">
         <source>%@ is not enabled.</source>
         <target>%@ não está ativado.</target>
         <note>Error label when the blocker is not enabled, shown in the intro and main app when disabled</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsOpen" xml:space="preserve">
+      <trans-unit id="Safari.instructionsOpen">
         <source>Open Settings App</source>
         <target>Abrir configurações do aplicativo</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Save" xml:space="preserve">
+      <trans-unit id="Save">
         <source>Save</source>
         <target>Salvar</target>
         <note>Save button label</note>
       </trans-unit>
-      <trans-unit id="SearchEngine.addEngineError" xml:space="preserve">
+      <trans-unit id="SearchEngine.addEngineError">
         <source>That didn't work. Try replacing the search term with this: %s.</source>
         <target>Isto não funcionou. Tente substituir o termo de pesquisa com isto: %s.</target>
         <note>Label for error state when entering an invalid search engine URL. %s is a search term in a URL.</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptDisable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptDisable">
         <source>No</source>
         <target>Não</target>
         <note>Label for disable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptEnable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptEnable">
         <source>Yes</source>
         <target>Sim</target>
         <note>Label for enable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptMessage" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptMessage">
         <source>To get suggestions, %@ needs to send what you type in the address bar to the search engine.</source>
         <target>Para receber sugestões, o %@ precisa enviar o que você escreve na barra de endereços para o mecanismo de pesquisa.</target>
         <note>%@ is the name of the app (Focus / Klar). Label for search suggestions prompt message</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptTitle" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptTitle">
         <source>Show Search Suggestions?</source>
         <target>Mostrar sugestões de pesquisa?</target>
         <note>Title for search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButton" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButton">
         <source>Add Another Search Engine</source>
         <target>Adicionar outro mecanismo de pesquisa</target>
         <note>Text for button to add another search engine in settings</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus">
         <source>+ Add Another Search Engine</source>
         <target>+ Adicionar outro mecanismo de pesquisa</target>
         <note>Text for button to add another search engine in settings with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineTitle" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineTitle">
         <source>Add Search Engine</source>
         <target>Adicionar mecanismo de pesquisa</target>
         <note>Title on add search engine settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.InstalledSearchEngines" xml:space="preserve">
+      <trans-unit id="Settings.Search.InstalledSearchEngines">
         <source>INSTALLED SEARCH ENGINES</source>
         <target>MECANISMOS DE PESQUISA INSTALADOS</target>
         <note>Header for rows of installed search engines</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NameToDisplay" xml:space="preserve">
+      <trans-unit id="Settings.Search.NameToDisplay">
         <source>Name to display</source>
         <target>Nome a ser exibido</target>
         <note>Label for input field for the name of the search engine to be added</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NewSearchEngineAdded" xml:space="preserve">
+      <trans-unit id="Settings.Search.NewSearchEngineAdded">
         <source>New Search Engine Added.</source>
         <target>Novo mecanismo de pesquisa adicionado.</target>
         <note>Toast displayed after adding a search engine</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.RestoreEngine" xml:space="preserve">
+      <trans-unit id="Settings.Search.RestoreEngine">
         <source>Restore Default Search Engines</source>
         <target>Restaurar os mecanismos de pesquisa padrões</target>
         <note>Label for button to bring deleted default engines back</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchEngineName" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchEngineName">
         <source>Search engine name</source>
         <target>Nome do mecanismo de pesquisa</target>
         <note>Placeholder text for input of new search engine name</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplate" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplate">
         <source>Search string to use</source>
         <target>Termo de pesquisa a ser usado</target>
         <note>Label for input of search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplatePlaceholder" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplatePlaceholder">
         <source>Paste or enter search string. If necessary, replace search term with: %s.</source>
         <target>Colar ou inserir um termo de pesquisa. Se necessário, substituir o termo da pesquisa com: %s.</target>
         <note>Placeholder text for input of new search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.autocompleteSection" xml:space="preserve">
+      <trans-unit id="Settings.autocompleteSection">
         <source>URL Autocomplete</source>
         <target>Preenchimento automático de URL</target>
         <note>Title for the URL Autocomplete row</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherMessage" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherMessage">
         <source>Blocking other content trackers may break some videos and web pages.</source>
         <target>O bloqueio de outros rastreadores pode quebrar alguns vídeos e páginas da Web.</target>
         <note>Alert message shown when toggling the Content blocker</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherNo2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherNo2">
         <source>Cancel</source>
         <target>Cancelar</target>
         <note>Button label for declining Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherYes2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherYes2">
         <source>Block Content Trackers</source>
         <target>Bloquear rastreadores de conteúdo</target>
         <note>Button label for accepting Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSearchSuggestion" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSearchSuggestion">
         <source>%@ will send what you type in the address bar to your search engine.</source>
         <target>O %@ enviará o que você escreve na barra de endereços para seu mecanismo de pesquisa.</target>
         <note>Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSendUsageData">
         <source>Mozilla strives to collect only what we need to provide and improve %@ for everyone.</source>
         <target>A Mozilla se empenha para coletar somente o que é necessário para melhorar o %@ para todos.</target>
         <note>Description associated to the Send Usage Data toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.learnMore" xml:space="preserve">
+      <trans-unit id="Settings.learnMore">
         <source>Learn more.</source>
         <target>Saiba mais.</target>
         <note>Subtitle for Send Anonymous Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.rate" xml:space="preserve">
+      <trans-unit id="Settings.rate">
         <source>Rate %@</source>
         <target>Avaliar o %@</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, allows the user to leave a review for the app on the app store.</note>
       </trans-unit>
-      <trans-unit id="Settings.safariTitle" xml:space="preserve">
+      <trans-unit id="Settings.safariTitle">
         <source>SAFARI INTEGRATION</source>
         <target>INTEGRAÇÃO DO SAFARI</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.screenTitle" xml:space="preserve">
+      <trans-unit id="Settings.screenTitle">
         <source>Settings</source>
         <target>Configurações</target>
         <note>Title for settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchLabel" xml:space="preserve">
+      <trans-unit id="Settings.searchLabel">
         <source>Search Engine</source>
         <target>Mecanismo de pesquisa</target>
         <note>Label for the search engine in the search screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchSuggestions" xml:space="preserve">
+      <trans-unit id="Settings.searchSuggestions">
         <source>Get Search Suggestions</source>
         <target>Receber sugestões de pesquisa</target>
         <note>Label for the Search Suggestions toggle row</note>
       </trans-unit>
-      <trans-unit id="Settings.searchTitle2" xml:space="preserve">
+      <trans-unit id="Settings.searchTitle2">
         <source>SEARCH</source>
         <target>PESQUISA</target>
         <note>Title for the search selection screen</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionIntegration" xml:space="preserve">
+      <trans-unit id="Settings.sectionIntegration">
         <source>INTEGRATION</source>
         <target>INTEGRAÇÃO</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionMozilla" xml:space="preserve">
+      <trans-unit id="Settings.sectionMozilla">
         <source>MOZILLA</source>
         <target>MOZILLA</target>
         <note>Section label for Mozilla toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPerformance" xml:space="preserve">
+      <trans-unit id="Settings.sectionPerformance">
         <source>PERFORMANCE</source>
         <target>DESEMPENHO</target>
         <note>Section label for performance toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPrivacy" xml:space="preserve">
+      <trans-unit id="Settings.sectionPrivacy">
         <source>PRIVACY</source>
         <target>PRIVACIDADE</target>
         <note>Section label for privacy toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionSecurity" xml:space="preserve">
+      <trans-unit id="Settings.sectionSecurity">
         <source>SECURITY</source>
         <target>SEGURANÇA</target>
         <note>Header label for security toggles displayed in the settings menu</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAds2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAds2">
         <source>Advertising</source>
         <target>Propaganda</target>
         <note>Label for the checkbox to toggle Advertising trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAnalytics2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAnalytics2">
         <source>Analytics</source>
         <target>Analíticos</target>
         <note>Label for the checkbox to toggle Analytics trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockFonts" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockFonts">
         <source>Block web fonts</source>
         <target>Bloquear fontes web</target>
         <note>Label for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockOther2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockOther2">
         <source>Content</source>
         <target>Conteúdo</target>
         <note>Label for the checkbox to toggle Other trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockSocial2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockSocial2">
         <source>Social</source>
         <target>Mídias sociais</target>
         <note>Label for the checkbox to toggle Social trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceID" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceID">
         <source>Use Face ID to unlock app</source>
         <target>Utilizar Face ID para desbloquear o aplicativo</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceIDDescription">
         <source>Face ID can unlock %@ if a URL is already open in the app</source>
         <target>O Face ID pode desbloquear o %@ se uma URL já estiver aberta no aplicativo</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Face ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleHomeScreenTips" xml:space="preserve">
+      <trans-unit id="Settings.toggleHomeScreenTips">
         <source>Show home screen tips</source>
         <target>Mostrar dicas na tela inicial</target>
         <note>Show home screen tips toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleOtherSubtitle" xml:space="preserve">
+      <trans-unit id="Settings.toggleOtherSubtitle">
         <source>May break some videos and Web pages</source>
         <target>Pode quebrar alguns vídeos e páginas web</target>
         <note>Label subtitle for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSafari" xml:space="preserve">
+      <trans-unit id="Settings.toggleSafari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Safari toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.toggleSendUsageData">
         <source>Send usage data</source>
         <target>Enviar dados de uso</target>
         <note>Label for Send Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchID" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchID">
         <source>Use Touch ID to unlock app</source>
         <target>Utilizar Touch ID para desbloquear o aplicativo</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchIDDescription">
         <source>Touch ID can unlock %@ if a URL is already open in the app</source>
         <target>O Touch ID pode desbloquear o %@ se uma URL já estiver aberta no aplicativo</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Touch ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOff" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOff">
         <source>Off</source>
         <target>Desativada</target>
         <note>Status off for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOn" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOn">
         <source>On</source>
         <target>Ativada</target>
         <note>Status on for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.whatsNewTitle" xml:space="preserve">
+      <trans-unit id="Settings.whatsNewTitle">
         <source>What’s New</source>
         <target>O que há de novo</target>
         <note>Title for What's new screen</note>
       </trans-unit>
-      <trans-unit id="Settinsg.siriShortcutsTitle" xml:space="preserve">
+      <trans-unit id="Settinsg.siriShortcutsTitle">
         <source>SIRI SHORTCUTS</source>
         <target>ATALHOS DA SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.FindInPage" xml:space="preserve">
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Procurar na página</target>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.GetFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.GetFirefox">
         <source>Get the Firefox App</source>
         <target>Instalar o Firefox</target>
         <note>Text for the share menu option when a user wants to open a page in Firefox but doesn’t have it installed. This string will not wrap in the interface. Instead, it will truncate. To prevent this, please keep the localized string to 18 or fewer characters. If your string runs longer than 18 characters, you can use 'Get Firefox' as the basis for your string. However, if at all possible, we’d like to signal to the user that they will be going to the App Store and installing the application from there. That is why we are using Get and App in the en-US string.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.PageActions" xml:space="preserve">
+      <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <target>Ações da página</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestDesktop" xml:space="preserve">
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
         <target>Requisitar site para desktop</target>
         <note>Text for the share menu option when a user wants to reload the site as a desktop</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestMobile" xml:space="preserve">
+      <trans-unit id="ShareMenu.RequestMobile">
         <source>Request Mobile Site</source>
         <target>Solicitar site para celular</target>
         <note>Text for the share menu option when a user wants to reload the site as a mobile device</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenChrome" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenChrome">
         <source>Open in Chrome</source>
         <target>Abrir no Chrome</target>
         <note>Text for the share menu option when a user wants to open the current website in the Chrome app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenFirefox">
         <source>Open in Firefox</source>
         <target>Abrir no Firefox</target>
         <note>Text for the share menu option when a user wants to open the current website in the Firefox app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenSafari" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenSafari">
         <source>Open in Safari</source>
         <target>Abrir no Safari</target>
         <note>Text for the share menu option when a user wants to open the current website in the Safari app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.SharePage" xml:space="preserve">
+      <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <target>Compartilhar página com…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
       </trans-unit>
-      <trans-unit id="Siri.add" xml:space="preserve">
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
+      </trans-unit>
+      <trans-unit id="Siri.add">
         <source>Add</source>
         <target>Adicionar</target>
         <note>Button to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.addTo" xml:space="preserve">
+      <trans-unit id="Siri.addTo">
         <source>Add to Siri</source>
         <target>Adicionar a Siri</target>
         <note>Button to add a specified shortcut option to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.editOpenUrl" xml:space="preserve">
+      <trans-unit id="Siri.editOpenUrl">
         <source>Re-Record or Delete Shortcut</source>
         <target>Regravar ou apagar atalho</target>
         <note>Label for button to edit the Siri phrase or delete the Siri functionality.</note>
       </trans-unit>
-      <trans-unit id="Siri.erase" xml:space="preserve">
+      <trans-unit id="Siri.erase">
         <source>Erase</source>
         <target>Apagar</target>
         <note>Title of option in settings to set up Siri to erase</note>
       </trans-unit>
-      <trans-unit id="Siri.eraseAndOpen" xml:space="preserve">
+      <trans-unit id="Siri.eraseAndOpen">
         <source>Erase &amp; Open</source>
         <target>Apagar e abrir</target>
         <note>Title of option in settings to set up Siri to erase and then open the app.</note>
       </trans-unit>
-      <trans-unit id="Siri.favoriteUrl" xml:space="preserve">
+      <trans-unit id="Siri.favoriteUrl">
         <source>Open Favorite Site</source>
         <target>Abrir site favorito</target>
         <note>Title for screen to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.openURL" xml:space="preserve">
+      <trans-unit id="Siri.openURL">
         <source>Open Favorite Site</source>
         <target>Abrir site favorito</target>
         <note>Title of option in settings to set up Siri to open a specified URL in Focus/Klar.</note>
       </trans-unit>
-      <trans-unit id="Siri.urlToOpen" xml:space="preserve">
+      <trans-unit id="Siri.urlToOpen">
         <source>URL to open</source>
         <target>URL a ser aberta</target>
         <note>Label for input to set a favorite URL to be opened by Siri.</note>
       </trans-unit>
-      <trans-unit id="URL.addToAutocompleteLabel" xml:space="preserve">
+      <trans-unit id="URL.addToAutocompleteLabel">
         <source>Add link to autocomplete</source>
         <target>Adicionar link para completar automaticamente</target>
         <note>Label displayed for button used as a shortcut to add a link to the list of URLs to autocomplete.</note>
       </trans-unit>
-      <trans-unit id="URL.cancelLabel" xml:space="preserve">
+      <trans-unit id="URL.cancelLabel">
         <source>Cancel</source>
         <target>Cancelar</target>
         <note>Label for cancel button shown when entering a URL or search</note>
       </trans-unit>
-      <trans-unit id="URL.contextMenu" xml:space="preserve">
+      <trans-unit id="URL.contextMenu">
         <source>Paste &amp; Go</source>
         <target>Colar e ir</target>
         <note>Text for the URL context menu when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.eraseButtonLabel" xml:space="preserve">
+      <trans-unit id="URL.eraseButtonLabel">
         <source>ERASE</source>
         <target>APAGAR</target>
         <note>Erase button in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.eraseMessageLabel2" xml:space="preserve">
+      <trans-unit id="URL.eraseMessageLabel2">
         <source>Browsing history cleared</source>
         <target>Histórico de navegação foi limpo</target>
         <note>Message shown after pressing the Erase button</note>
       </trans-unit>
-      <trans-unit id="URL.findOnPageLabel" xml:space="preserve">
+      <trans-unit id="URL.findOnPageLabel">
         <source>Find in page: %@</source>
         <target>Procurar na página: %@</target>
         <note>Label displayed for find in page button when typing in the URL Bar. %@ is any text the user has typed into the URL bar that they want to find on the current page.</note>
       </trans-unit>
-      <trans-unit id="URL.paste" xml:space="preserve">
+      <trans-unit id="URL.paste">
         <source>Paste</source>
         <target>Colar</target>
         <note>Text for a menu displayed from the bottom of the screen when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.placeholderText" xml:space="preserve">
+      <trans-unit id="URL.placeholderText">
         <source>Search or enter address</source>
         <target>Pesquisar ou digitar um endereço</target>
         <note>Placeholder text shown in the URL bar before the user navigates to a page</note>
       </trans-unit>
-      <trans-unit id="URL.searchLabel" xml:space="preserve">
+      <trans-unit id="URL.searchLabel">
         <source>Search for %@</source>
         <target>Pesquisar por %@</target>
         <note>Label displayed for search button when typing in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="URL.trackersBlockedLabel">
         <source>Trackers blocked</source>
         <target>Rastreadores bloqueados</target>
         <note>Text for the URL bar showing the number of trackers blocked on a webpage.</note>
       </trans-unit>
-      <trans-unit id="actionSheet.openIn" xml:space="preserve">
+      <trans-unit id="actionSheet.openIn">
         <source>Open in %@</source>
         <target>Abrir com %@</target>
         <note>Title for action sheet item to open the current page in another application. Placeholder is the name of the application to open the current page.</note>
       </trans-unit>
-      <trans-unit id="browser.copyAddressToast" xml:space="preserve">
+      <trans-unit id="browser.copyAddressToast">
         <source>URL Copied To Clipboard</source>
         <target>URL copiado para a área de transferência</target>
         <note>Toast displayed after a URL has been copied to the clipboard</note>
       </trans-unit>
-      <trans-unit id="browserShortcutDescription.selectLocationBar" xml:space="preserve">
+      <trans-unit id="browserShortcutDescription.selectLocationBar">
         <source>Select Location Bar</source>
         <target>Selecionar barra de localização</target>
         <note>Label to display in the Discoverability overlay for keyboard shortcuts</note>
       </trans-unit>
-      <trans-unit id="contextMenu.clipboardLink" xml:space="preserve">
+      <trans-unit id="contextMenu.clipboardLink">
         <source>Link you copied: %@</source>
         <target>Link copiado: %@</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.copyImageTitle">
         <source>Copy Image</source>
         <target>Copiar imagem</target>
         <note>Text for the context menu when a user wants to copy an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyLink" xml:space="preserve">
+      <trans-unit id="contextMenu.copyLink">
         <source>Copy Link</source>
         <target>Copiar link</target>
         <note>Text for the context menu when a user wants to copy a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.linkCopied" xml:space="preserve">
+      <trans-unit id="contextMenu.linkCopied">
         <source>Link you copied: </source>
         <target>Link que você copiou:</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.saveImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.saveImageTitle">
         <source>Save Image</source>
         <target>Salvar imagem</target>
         <note>Text for the context menu when a user wants to save an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.shareLinkTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.shareLinkTitle">
         <source>Share Link</source>
         <target>Compartilhar link</target>
         <note>Text for the context menu when a user wants to share a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="externalAppLinkWithAppName.messageTitle" xml:space="preserve">
+      <trans-unit id="externalAppLinkWithAppName.messageTitle">
         <source>%1$@ wants to open %2$@</source>
         <target>%1$@ quer abrir %2$@</target>
         <note>Dialog title used for opening an external app from Focus. First placeholder string is the app name of either Focus or Klar and the second placeholder string specifies the app it wants to open.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.description" xml:space="preserve">
+      <trans-unit id="photosPermission.description">
         <source>This lets you save images to your Camera Roll</source>
         <target>Isso permite que salve a imagem na sua galeria de imagens</target>
         <note>Description for dialog used for requesting a user to enable access to Photos.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.openSettings" xml:space="preserve">
+      <trans-unit id="photosPermission.openSettings">
         <source>Open Settings</source>
         <target>Abrir configurações</target>
         <note>Title for button that takes the user to system settings</note>
       </trans-unit>
-      <trans-unit id="photosPermission.title" xml:space="preserve">
+      <trans-unit id="photosPermission.title">
         <source>“%@” Would Like to Access Your Photos</source>
         <target>“%@” gostaria de acessar suas fotos</target>
         <note>Dialog title used for requesting a user to enable access to Photos. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="settings.Search.SearchTemplateExample" xml:space="preserve">
+      <trans-unit id="settings.Search.SearchTemplateExample">
         <source>Example: searchengineexample.com/search/?q=%s</source>
         <target>Exemplo: nomedomecanismodepesquisa.com/search/?q= %s</target>
         <note>Text displayed as an example of the template to add a search engine.</note>
       </trans-unit>
-      <trans-unit id="share" xml:space="preserve">
+      <trans-unit id="share">
         <source>Share</source>
         <target>Compartilhar</target>
         <note>Text for a share button</note>
       </trans-unit>
-      <trans-unit id="shareMenu.copyAddress" xml:space="preserve">
+      <trans-unit id="shareMenu.copyAddress">
         <source>Copy Address</source>
         <target>Copiar endereço</target>
         <note>Text for the share menu when a user wants to copy a URL.</note>
       </trans-unit>
-      <trans-unit id="touchId.reason" xml:space="preserve">
+      <trans-unit id="touchId.reason">
         <source>Use Touch ID to return to %@</source>
         <target>Utilizar o Touch ID para retornar para o %@</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.adTrackersLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.adTrackersLabel">
         <source>Ad trackers</source>
         <target>Rastreadores de anúncios</target>
         <note>Label for ad trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.analyticTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.analyticTrackerLabel">
         <source>Analytic trackers</source>
         <target>Rastreadores analíticos</target>
         <note>label for analytic trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.contentTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>
         <target>Rastreadores de conteúdo</target>
         <note>label for content trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.disabledLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.disabledLabel">
         <source>Tracking Protection off</source>
         <target>Proteção contra rastreamento desligada</target>
         <note>text showing the tracking protection is disabled.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.label" xml:space="preserve">
+      <trans-unit id="trackingProtection.label">
         <source>Tracking Protection</source>
         <target>Proteção contra rastreamento</target>
         <note>Title for the tracking settings page to change what trackers are blocked.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.labelDescription" xml:space="preserve">
+      <trans-unit id="trackingProtection.labelDescription">
         <source>Turning this off may fix some site problems</source>
         <target>Desligar isso pode resolver alguns problemas do site</target>
         <note>Description/subtitle for the tracking protection label.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.learnMore" xml:space="preserve">
+      <trans-unit id="trackingProtection.learnMore">
         <source>Learn More</source>
         <target>Saiba mais</target>
         <note>Text for the button to learn more about Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.moreSettings" xml:space="preserve">
+      <trans-unit id="trackingProtection.moreSettings">
         <source>More Settings</source>
         <target>Mais configurações</target>
         <note>Text for the button that closes the Shield Data and opens the regular Settings screen.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.socialTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.socialTrackerLabel">
         <source>Social trackers</source>
         <target>Rastreadores sociais</target>
         <note>label for social trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOff" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOff">
         <source>Protections are OFF for this session</source>
         <target>As proteções estão DESATIVADAS nesta sessão</target>
         <note>Text for the status off from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOn" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOn">
         <source>Protections are ON for this session</source>
         <target>As proteções estão ATIVADAS nesta sessão</target>
         <note>Text for the status on from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleDescription1" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleDescription1">
         <source>Disable until you close %@ or tap ERASE.</source>
         <target>Desabilitar até você fechar o %@ ou tocar em APAGAR.</target>
         <note>Description for the tracking protection toggle. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleLabel2">
         <source>Enhanced Tracking Protection</source>
         <target>Proteção aprimorada contra rastreamento</target>
         <note>Text for the toggle that enables/disables tracking protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackerDescriptionLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackerDescriptionLabel2">
         <source>Keep your data to yourself. %@ protects you from many of the most common trackers that follow what you do online.</source>
         <target>Mantenha seus dados com você. O %@ te protege de muitos dos rastreadores mais comuns que tentam seguir o que você faz online.</target>
         <note>General description of tracking protection settings, which is displayed underneath the trackers preferences in Settings. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersBlockedLabel">
         <source>Trackers blocked since %@</source>
         <target>Rastreadores bloqueados desde %@</target>
         <note>Text for tracking protection screen showing the number of trackers blocked since the app install. The placeholder is replaced with the install date of the application.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersHeader" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersHeader">
         <source>Trackers and scripts to block</source>
         <target>Rastreadores e scripts a bloquear</target>
         <note>Text for the header of trackers section from Tracking Protection.</note>
@@ -1078,7 +1097,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="SettingsBundle.Licenses" xml:space="preserve">
+      <trans-unit id="SettingsBundle.Licenses">
         <source>Licenses</source>
         <target>Licenças</target>
         <note>The title of the Licenses setting in the settings that Focus shows in the global iOS Settings app.</note>
@@ -1086,3 +1105,4 @@
     </body>
   </file>
 </xliff>
+

--- a/pt-PT/focus-ios.xliff
+++ b/pt-PT/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>ATALHOS DE SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Localizar na página</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>Ações da página</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>Partilhar página com…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>Trackers de analítica</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/ro/focus-ios.xliff
+++ b/ro/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>SCURTĂTURI SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Caută în pagină</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>Acțiuni pe pagină</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>Partajează pagina cu...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>Elemente de urmărire analitice</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/ru/focus-ios.xliff
+++ b/ru/focus-ios.xliff
@@ -761,6 +761,10 @@
         <target>БЫСТРЫЕ КОМАНДЫ SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Найти на странице</target>
@@ -775,6 +779,10 @@
         <source>Page Actions</source>
         <target>Действия на странице</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -805,6 +813,10 @@
         <source>Share Page With...</source>
         <target>Поделиться через...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -990,6 +1002,14 @@
         <source>Analytic trackers</source>
         <target>Трекеры аналитики</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/ses/focus-ios.xliff
+++ b/ses/focus-ios.xliff
@@ -25,6 +25,7 @@
       </trans-unit>
       <trans-unit id="NSPhotoLibraryAddUsageDescription">
         <source>This lets you save and upload photos.</source>
+        <target>This lets you save and upload photos.</target>
         <note>Privacy - Photo Library Additions Usage Description</note>
       </trans-unit>
       <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen">
@@ -670,6 +671,10 @@
         <source>SIRI SHORTCUTS</source>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
@@ -681,6 +686,10 @@
       <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -705,6 +714,10 @@
       <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -857,6 +870,14 @@
       <trans-unit id="trackingProtection.analyticTrackerLabel">
         <source>Analytic trackers</source>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/sk/focus-ios.xliff
+++ b/sk/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>SKRATKY PRE SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Hľadať na stránke</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>Akcie stránky</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>Zdieľať stránku s…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>Analytické sledovacie prvky</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/sl/focus-ios.xliff
+++ b/sl/focus-ios.xliff
@@ -151,7 +151,6 @@
       </trans-unit>
       <trans-unit id="About.safariBullet2">
         <source>Block web fonts to reduce page size</source>
-        <target>Zavračajte spletne pisave za hitrejše nalaganje strani</target>
         <note>Label on About screen</note>
       </trans-unit>
       <trans-unit id="About.safariBulletHeader">
@@ -599,7 +598,6 @@
       </trans-unit>
       <trans-unit id="Settings.blockOtherMessage">
         <source>Blocking other content trackers may break some videos and web pages.</source>
-        <target>Zavračanje ostalih vsebinskih sledilcev lahko pokvari nekatere videoposnetke in strani.</target>
         <note>Alert message shown when toggling the Content blocker</note>
       </trans-unit>
       <trans-unit id="Settings.blockOtherNo2">
@@ -690,7 +688,6 @@
       </trans-unit>
       <trans-unit id="Settings.toggleBlockFonts">
         <source>Block web fonts</source>
-        <target>Zavračaj spletne pisave</target>
         <note>Label for toggle on main screen</note>
       </trans-unit>
       <trans-unit id="Settings.toggleBlockOther2">
@@ -759,6 +756,10 @@
         <target>BLIŽNJICE ZA SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Najdi na strani</target>
@@ -773,6 +774,10 @@
         <source>Page Actions</source>
         <target>Dejanja strani</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -803,6 +808,10 @@
         <source>Share Page With...</source>
         <target>Deli stran z …</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -988,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>Analitični sledilci</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/sq/focus-ios.xliff
+++ b/sq/focus-ios.xliff
@@ -757,6 +757,10 @@
         <target>SHKURTORE SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Gjej në Faqe</target>
@@ -771,6 +775,10 @@
         <source>Page Actions</source>
         <target>Veprime Faqeje</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -801,6 +809,10 @@
         <source>Share Page With...</source>
         <target>Ndajeni Faqen Me…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -985,6 +997,14 @@
         <source>Analytic trackers</source>
         <target>Gjurmues analitikë</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/sv-SE/focus-ios.xliff
+++ b/sv-SE/focus-ios.xliff
@@ -761,6 +761,10 @@
         <target>SIRI GENVÄGAR</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Hitta på sidan</target>
@@ -775,6 +779,10 @@
         <source>Page Actions</source>
         <target>Åtgärder för sida</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -805,6 +813,10 @@
         <source>Share Page With...</source>
         <target>Dela sida med...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -990,6 +1002,14 @@
         <source>Analytic trackers</source>
         <target>Analys trackers</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/ta/focus-ios.xliff
+++ b/ta/focus-ios.xliff
@@ -744,6 +744,10 @@
         <source>SIRI SHORTCUTS</source>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>பக்கத்தில் கண்டுபிடி</target>
@@ -757,6 +761,10 @@
       <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -782,6 +790,10 @@
       <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -953,6 +965,14 @@
         <source>Analytic trackers</source>
         <target>பகுப்பாய்வு பின்தொடரிகள்</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/te/focus-ios.xliff
+++ b/te/focus-ios.xliff
@@ -720,6 +720,10 @@
         <source>SIRI SHORTCUTS</source>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>పేజీలో వెతుకు</target>
@@ -734,6 +738,10 @@
         <source>Page Actions</source>
         <target>పేజీ చర్యలు</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -761,6 +769,10 @@
       <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -939,6 +951,14 @@
         <source>Analytic trackers</source>
         <target>వైశ్లేషిక ట్రాకర్లు</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/templates/focus-ios.xliff
+++ b/templates/focus-ios.xliff
@@ -621,6 +621,10 @@
         <source>SIRI SHORTCUTS</source>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
@@ -632,6 +636,10 @@
       <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -656,6 +664,10 @@
       <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -804,6 +816,14 @@
       <trans-unit id="trackingProtection.analyticTrackerLabel">
         <source>Analytic trackers</source>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/th/focus-ios.xliff
+++ b/th/focus-ios.xliff
@@ -761,6 +761,10 @@
         <target>คำสั่งลัด SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>ค้นหาในหน้า</target>
@@ -775,6 +779,10 @@
         <source>Page Actions</source>
         <target>การกระทำหน้า</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -805,6 +813,10 @@
         <source>Share Page With...</source>
         <target>แบ่งปันหน้าด้วย...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -990,6 +1002,14 @@
         <source>Analytic trackers</source>
         <target>ตัวติดตามของการวิเคราะห์</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/tl/focus-ios.xliff
+++ b/tl/focus-ios.xliff
@@ -745,6 +745,10 @@
         <target>SIRI SHORTCUTS</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Hanapin sa Pahina</target>
@@ -759,6 +763,10 @@
         <source>Page Actions</source>
         <target>Mga Pagkilos ng Pahina</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -788,6 +796,10 @@
         <source>Share Page With...</source>
         <target>Ibahagi ang Pahina Sa...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -971,6 +983,14 @@
         <source>Analytic trackers</source>
         <target>Analytic trackers</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/tr/focus-ios.xliff
+++ b/tr/focus-ios.xliff
@@ -761,6 +761,10 @@
         <target>SIRI KESTİRMELERİ</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Sayfada Bul</target>
@@ -775,6 +779,10 @@
         <source>Page Actions</source>
         <target>Sayfa eylemleri</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -805,6 +813,10 @@
         <source>Share Page With...</source>
         <target>Sayfayı paylaş...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -990,6 +1002,14 @@
         <source>Analytic trackers</source>
         <target>Analitik takipçileri</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/uk/focus-ios.xliff
+++ b/uk/focus-ios.xliff
@@ -1,36 +1,35 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Blockzilla/en.lproj/InfoPlist.strings" source-language="en" target-language="uk" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="NSCameraUsageDescription" xml:space="preserve">
+      <trans-unit id="NSCameraUsageDescription">
         <source>This lets you take and upload photos.</source>
         <target>Це дозволяє вам знімати й вивантажувати фото.</target>
         <note>Privacy - Camera Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSFaceIDUsageDescription" xml:space="preserve">
+      <trans-unit id="NSFaceIDUsageDescription">
         <source>This lets you unlock the app.</source>
         <target>Це дозволить вам блокувати програму.</target>
         <note>Privacy - Face ID Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSLocationWhenInUseUsageDescription" xml:space="preserve">
+      <trans-unit id="NSLocationWhenInUseUsageDescription">
         <source>Websites you visit may request your location.</source>
         <target>Відвідувані вами веб-сайти можуть запитувати ваше розташування.</target>
         <note>Privacy - Location When In Use Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSMicrophoneUsageDescription" xml:space="preserve">
+      <trans-unit id="NSMicrophoneUsageDescription">
         <source>This lets you take and upload videos.</source>
         <target>Це дозволяє вам знімати й вивантажувати відео.</target>
         <note>Privacy - Microphone Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSPhotoLibraryAddUsageDescription" xml:space="preserve">
+      <trans-unit id="NSPhotoLibraryAddUsageDescription">
         <source>This lets you save and upload photos.</source>
         <target>Це дозволяє вам знімати й вивантажувати фото.</target>
         <note>Privacy - Photo Library Additions Usage Description</note>
       </trans-unit>
-      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen" xml:space="preserve">
+      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen">
         <source>Erase and Open</source>
         <target>Стерти і відкрити</target>
         <note>This is the menu item that appears when you long press the Focus icon on the phone home screen.</note>
@@ -42,7 +41,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intents.Erase.Title" xml:space="preserve">
+      <trans-unit id="Intents.Erase.Title">
         <source>Erase</source>
         <target>Стерти</target>
         <note>Title of the Erase intent.</note>
@@ -54,42 +53,42 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intro.Slides.History.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Description">
         <source>Clear your entire browsing session history, passwords, cookies anytime with a single tap.</source>
         <target>Одним дотиком, будь-коли стирайте всю історію сеансу, паролі та куки.</target>
         <note>Description for the 'History' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.History.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Title">
         <source>Your history is history</source>
         <target>Ваша історія залишається історією</target>
         <note>Title for the third  panel 'History' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Next.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Next.Button">
         <source>Next</source>
         <target>Далі</target>
         <note>Button to go to the next card in Focus onboarding.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Description">
         <source>Searching for something different? Choose a different search engine.</source>
         <target>Шукаєте щось інше? Оберіть інший пошуковий засіб.</target>
         <note>Description for the 'Favorite Search Engine' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Title">
         <source>Your search, your way</source>
         <target>Ваш пошук, ваш шлях</target>
         <note>Title for the second  panel 'Search' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Skip.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Skip.Button">
         <source>Skip</source>
         <target>Пропустити</target>
         <note>Button to skip onboarding in Focus</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Description">
         <source>Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times.</source>
         <target>Перейдіть на вищий рівень приватного перегляду. Блокуйте рекламу та інший вміст, що може стежити за вами на сайтах і сповільнювати завантаження сторінок.</target>
         <note>Description for the 'Welcome' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Title">
         <source>Power up your privacy</source>
         <target>Прокачайте вашу приватність</target>
         <note>Title for the first panel 'Welcome' in the First Run tour.</note>
@@ -101,984 +100,1004 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="About.learnMoreButton" xml:space="preserve">
+      <trans-unit id="About.learnMoreButton">
         <source>Learn more</source>
         <target>Докладніше</target>
         <note>Button on About screen</note>
       </trans-unit>
-      <trans-unit id="About.missionLabel" xml:space="preserve">
+      <trans-unit id="About.missionLabel">
         <source>%@ is produced by Mozilla. Our mission is to foster a healthy, open Internet.</source>
         <target>%@ створено в Mozilla. Нашою місією є сприяння розвитку здорового, відкритого Інтернету.</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet1" xml:space="preserve">
+      <trans-unit id="About.privateBullet1">
         <source>Search and browse right in the app</source>
         <target>Пошук і перегляд прямо в програмі</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet2" xml:space="preserve">
+      <trans-unit id="About.privateBullet2">
         <source>Block trackers (or update settings to allow trackers)</source>
         <target>Блокуйте стеження (або оновіть налаштування, щоб дозволити стеження)</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet3" xml:space="preserve">
+      <trans-unit id="About.privateBullet3">
         <source>Erase to delete cookies as well as search and browsing history</source>
         <target>Стирайте для видалення куків, а також історії пошуку й перегляду</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBulletHeader" xml:space="preserve">
+      <trans-unit id="About.privateBulletHeader">
         <source>Use it as a private browser:</source>
         <target>Використовуйте в якості приватного браузера:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowHelp" xml:space="preserve">
+      <trans-unit id="About.rowHelp">
         <source>Help</source>
         <target>Допомога</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowPrivacy" xml:space="preserve">
+      <trans-unit id="About.rowPrivacy">
         <source>Privacy Notice</source>
         <target>Повідомлення про приватність</target>
         <note>Link to Privacy Notice in the About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowRights" xml:space="preserve">
+      <trans-unit id="About.rowRights">
         <source>Your Rights</source>
         <target>Ваші права</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet1" xml:space="preserve">
+      <trans-unit id="About.safariBullet1">
         <source>Block trackers for improved privacy</source>
         <target>Блокуйте стеження для покращення приватності</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet2" xml:space="preserve">
+      <trans-unit id="About.safariBullet2">
         <source>Block web fonts to reduce page size</source>
         <target>Блокуйте веб-шрифти для зменшення розміру сторінок</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBulletHeader" xml:space="preserve">
+      <trans-unit id="About.safariBulletHeader">
         <source>Use it as a Safari extension:</source>
         <target>Використовуйте в якості розширення для Safari:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.title" xml:space="preserve">
+      <trans-unit id="About.title">
         <source>About %@</source>
         <target>Про %@</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, takes the user to a page with information about the product. Also displayed as a header for the About page.</note>
       </trans-unit>
-      <trans-unit id="About.topLabel" xml:space="preserve">
+      <trans-unit id="About.topLabel">
         <source>%@ puts you in control.</source>
         <target>%@ надає вам контроль.</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Dismiss" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Dismiss">
         <source>Ok</source>
         <target>Гаразд</target>
         <note>Button to dismiss the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Message" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Message">
         <source>An error occured while adding the pass to Wallet. Please try again later.</source>
         <target>При додаванні картки до Wallet сталася помилка. Спробуйте знову пізніше.</target>
         <note>Message of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Title" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Title">
         <source>Failed to Add Pass</source>
         <target>Не вдалося додати картку</target>
         <note>Title of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="Authentication.reason" xml:space="preserve">
+      <trans-unit id="Authentication.reason">
         <source>Authenticate to return to %@</source>
         <target>Зареєструйтеся для повернення до %@</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID, Face ID, or passcode to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrl">
         <source>Add Custom URL</source>
         <target>Додати власну URL-адресу</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlError" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlError">
         <source>Double-check the URL you entered.</source>
         <target>Уважно перевірте введену URL-адресу.</target>
         <note>Label for error state when entering an invalid URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlExample" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlExample">
         <source>Example: example.com</source>
         <target>Зразок: example.com</target>
         <note>A label displaying an example URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlLabel">
         <source>URL to add</source>
         <target>URL для додавання</target>
         <note>Label for the input to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlPlaceholder" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlPlaceholder">
         <source>Paste or enter URL</source>
         <target>Вставте чи введіть URL-адресу</target>
         <note>Placeholder for the input field to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlWithPlus" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlWithPlus">
         <source>+ Add Custom URL</source>
         <target>+ Додати власну URL-адресу</target>
         <note>Label for button to add a custom URL with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.customDescriptoin">
         <source>Add and manage custom autocomplete URLs.</source>
         <target>Додавайте і керуйте автозавершенням власних URL-адрес.</target>
         <note>Description for adding and managing custom autocomplete URLs</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.customLabel">
         <source>Custom URLs</source>
         <target>Власні URL</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.customTitle">
         <source>CUSTOM URL LIST</source>
         <target>ПЕРЕЛІК ВЛАСНИХ URL</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customUrlAdded" xml:space="preserve">
+      <trans-unit id="Autocomplete.customUrlAdded">
         <source>New Custom URL added.</source>
         <target>Нову власну URL-адресу додано.</target>
         <note>Label for toast alerting a custom URL has been added</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultDescriptoin">
         <source>Enable to have %@ autocomplete over 450 popular URLs in the address bar.</source>
         <target>Увімкніть автозавершення в %@ для понад 450 популярних URL-адрес в панелі адреси.</target>
         <note>Description for enabling or disabling the default list. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultLabel">
         <source>Autocomplete</source>
         <target>Автозавершення</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultTitle">
         <source>DEFAULT URL LIST</source>
         <target>ТИПОВИЙ ПЕРЕЛІК URL</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.disabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.disabled">
         <source>Disabled</source>
         <target>Вимкнено</target>
         <note>label describing URL Autocomplete as disabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.duplicateUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.duplicateUrl">
         <source>URL already exists</source>
         <target>URL вже наявний</target>
         <note>Label for toast alerting that the custom URL being added is a duplicate</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.emptyState" xml:space="preserve">
+      <trans-unit id="Autocomplete.emptyState">
         <source>No Custom URLs to display</source>
         <target>Немає власних URL-адрес для показу</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.enabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.enabled">
         <source>Enabled</source>
         <target>Увімкнено</target>
         <note>label describing URL Autocomplete as enabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.manageSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.manageSites">
         <source>Manage Sites</source>
         <target>Керувати сайтами</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySites" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySites">
         <source>My Sites</source>
         <target>Мої сайти</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySitesDesc" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySitesDesc">
         <source>Enable to have %@ autocomplete your favorite URLs.</source>
         <target>Увімкнути, щоб %@ автоматично завершував URL-адреси популярних сайтів.</target>
         <note>Description for adding and managing custom autocomplete URLs. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.topSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.topSites">
         <source>Top Sites</source>
         <target>Популярні сайти</target>
         <note>Label for enabling or disabling top sites</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.newSession" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.newSession">
         <source>New Session</source>
         <target>Новий сеанс</target>
         <note>Create a new session after failing a biometric check</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.reason" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.reason">
         <source>Unlock %@ when re-opening in order to prevent unauthorized access.</source>
         <target>Блокуйте %@ при повторному відкритті для запобігання небажаного доступу.</target>
         <note>%@ is app name. Explanation for why the app needs access to biometric information. Prompt is only shown once when the user first tries to enable Face ID to open the app.</note>
       </trans-unit>
-      <trans-unit id="Browser.backLabel" xml:space="preserve">
+      <trans-unit id="Browser.backLabel">
         <source>Back</source>
         <target>Назад</target>
         <note>Accessibility label for the back button</note>
       </trans-unit>
-      <trans-unit id="Browser.copyAddressLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyAddressLabel">
         <source>Copy Address</source>
         <target>Копіювати адресу</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.copyMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyMenuLabel">
         <source>Copy</source>
         <target>Копіювати</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.customURLMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.customURLMenuLabel">
         <source>Add Custom URL</source>
         <target>Додати власну URL-адресу</target>
         <note>Custom URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.forwardLabel" xml:space="preserve">
+      <trans-unit id="Browser.forwardLabel">
         <source>Forward</source>
         <target>Вперед</target>
         <note>Accessibility label for the forward button</note>
       </trans-unit>
-      <trans-unit id="Browser.reloadLabel" xml:space="preserve">
+      <trans-unit id="Browser.reloadLabel">
         <source>Reload</source>
         <target>Перезавантажити</target>
         <note>Accessibility label for the reload button</note>
       </trans-unit>
-      <trans-unit id="Browser.settingsLabel" xml:space="preserve">
+      <trans-unit id="Browser.settingsLabel">
         <source>Settings</source>
         <target>Параметри</target>
         <note>Accessibility label for the settings button</note>
       </trans-unit>
-      <trans-unit id="Browser.shareLabel" xml:space="preserve">
+      <trans-unit id="Browser.shareLabel">
         <source>Share</source>
         <target>Поділитися</target>
         <note>Accessibility label for the share button</note>
       </trans-unit>
-      <trans-unit id="Browser.stopLabel" xml:space="preserve">
+      <trans-unit id="Browser.stopLabel">
         <source>Stop</source>
         <target>Стоп</target>
         <note>Accessibility label for the stop button</note>
       </trans-unit>
-      <trans-unit id="Cancel" xml:space="preserve">
+      <trans-unit id="Cancel">
         <source>Cancel</source>
         <target>Скасувати</target>
         <note>Label on button to cancel edits</note>
       </trans-unit>
-      <trans-unit id="Done" xml:space="preserve">
+      <trans-unit id="Done">
         <source>Done</source>
         <target>Готово</target>
         <note>Label on button to complete edits</note>
       </trans-unit>
-      <trans-unit id="Edit" xml:space="preserve">
+      <trans-unit id="Edit">
         <source>Edit</source>
         <target>Змінити</target>
         <note>Label on button to allow edits</note>
       </trans-unit>
-      <trans-unit id="Error.tryAgainButton" xml:space="preserve">
+      <trans-unit id="Error.tryAgainButton">
         <source>Try again</source>
         <target>Спробувати знову</target>
         <note>Button label to reload the error page</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.cancelTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.cancelTitle">
         <source>Cancel</source>
         <target>Скасувати</target>
         <note>Button label used for cancelling to open another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.messageTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.messageTitle">
         <source>%@ wants to open another App</source>
         <target>%@ хоче відкрити іншу програму</target>
         <note>Dialog title used for opening an external app from Focus. The placeholder string is the app name of either Focus or Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.openTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.openTitle">
         <source>Open</source>
         <target>Відкрити</target>
         <note>Button label for opening another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.callButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.callButton">
         <source>Call</source>
         <target>Виклик</target>
         <note>Button label in tel: dialog to call a phone number. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.cancelButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.cancelButton">
         <source>Cancel</source>
         <target>Скасувати</target>
         <note>Button label in external link dialog to cancel the dialog. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.emailButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.emailButton">
         <source>Email</source>
         <target>Е-пошта</target>
         <note>Button label in mailto: dialog to send an email. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.messageTitleWithPlaceholder" xml:space="preserve">
+      <trans-unit id="ExternalLink.messageTitleWithPlaceholder">
         <source>You are now leaving %@.</source>
         <target>Ви виходите з %@.</target>
         <note>Dialog title used for Maps/App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreButton">
         <source>Open App Store</source>
         <target>Відкрити App Store</target>
         <note>Button label in App Store URL dialog to open the App Store. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreTitle" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreTitle">
         <source>%@ wants to open the App Store.</source>
         <target>%@ хоче відкрити App Store.</target>
         <note>Dialog title used to open App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openMapsButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openMapsButton">
         <source>Open Maps</source>
         <target>Відкрити карти</target>
         <note>Button label in Maps URL dialog to open Maps. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="FindInPage.Done" xml:space="preserve">
+      <trans-unit id="FindInPage.Done">
         <source>Find in page done</source>
         <target>Пошук на сторінці завершено</target>
         <note>Accessibility label for done button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.NextResult" xml:space="preserve">
+      <trans-unit id="FindInPage.NextResult">
         <source>Find next in page</source>
         <target>Знайти далі</target>
         <note>Accessibility label for next result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.PreviousResult" xml:space="preserve">
+      <trans-unit id="FindInPage.PreviousResult">
         <source>Find previous in page</source>
         <target>Знайти попереднє</target>
         <note>Accessibility label for previous result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FirstRun.lastSlide.buttonLabel" xml:space="preserve">
+      <trans-unit id="FirstRun.lastSlide.buttonLabel">
         <source>OK, Got It!</source>
         <target>Гаразд, зрозуміло!</target>
         <note>Label on button to dismiss first run UI</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelDescription" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelDescription">
         <source>Automatically block online trackers while you browse. Then tap to erase visited pages, searches, cookies and passwords from your device.</source>
         <target>Автоматично блокуйте стеження онлайн під час перегляду. Потім торкніться, щоб стерти відвідані сторінки, пошукові запити, куки й паролі з вашого пристрою.</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelTagline" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelTagline">
         <source>Browse like no one’s watching.</source>
         <target>Переглядайте без думки, що за вами хтось спостерігає.</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="Focus.handoffSyncing" xml:space="preserve">
+      <trans-unit id="Focus.handoffSyncing">
         <source>Apple Handoff is syncing</source>
         <target>Синхронізація Apple Handoff</target>
         <note>Title for the loading screen when the handoff of clipboard delays Focus launch. “Handoff” should not be localized, see https://support.apple.com/HT204681</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel1" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel1">
         <source>Automatic private browsing.</source>
         <target>Автоматичний приватний перегляд.</target>
         <note>First label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel2" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel2">
         <source>Browse. Erase. Repeat.</source>
         <target>Переглядайте. Стирайте. Повторюйте знову.</target>
         <note>Second label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Menu.Close" xml:space="preserve">
+      <trans-unit id="Menu.Close">
         <source>Close</source>
         <target>Закрити</target>
         <note>Button label used to close a menu that displays as a popup.</note>
       </trans-unit>
-      <trans-unit id="Open.Cancel" xml:space="preserve">
+      <trans-unit id="Open.Cancel">
         <source>Cancel</source>
         <target>Скасувати</target>
         <note>Label in share alert to cancel the alert</note>
       </trans-unit>
-      <trans-unit id="Open.Firefox" xml:space="preserve">
+      <trans-unit id="Open.Firefox">
         <source>Firefox (Private Browsing)</source>
         <target>Firefox (Приватний перегляд)</target>
         <note>Label in share alert to open the URL in Firefox</note>
       </trans-unit>
-      <trans-unit id="Open.More" xml:space="preserve">
+      <trans-unit id="Open.More">
         <source>More</source>
         <target>Більше</target>
         <note>Label in share alert to open the full system share menu</note>
       </trans-unit>
-      <trans-unit id="Open.Safari" xml:space="preserve">
+      <trans-unit id="Open.Safari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Label in share alert to open the URL in Safari</note>
       </trans-unit>
-      <trans-unit id="Request Desktop Site" xml:space="preserve">
+      <trans-unit id="Request Desktop Site">
         <source>Request Desktop Site</source>
         <target>Повна версія сайту</target>
         <note>Label for button that requests the desktop version of the currently loaded website.</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsContentBlockers" xml:space="preserve">
+      <trans-unit id="Safari.instructionsContentBlockers">
         <source>Tap Safari, then select Content Blockers</source>
         <target>Оберіть Safari, потім оберіть Блокувальники вмісту</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsEnable" xml:space="preserve">
+      <trans-unit id="Safari.instructionsEnable">
         <source>Enable %@</source>
         <target>Увімкніть %@</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsNotEnabled" xml:space="preserve">
+      <trans-unit id="Safari.instructionsNotEnabled">
         <source>%@ is not enabled.</source>
         <target>%@ не увімкнено.</target>
         <note>Error label when the blocker is not enabled, shown in the intro and main app when disabled</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsOpen" xml:space="preserve">
+      <trans-unit id="Safari.instructionsOpen">
         <source>Open Settings App</source>
         <target>Відкрийте параметри</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Save" xml:space="preserve">
+      <trans-unit id="Save">
         <source>Save</source>
         <target>Зберегти</target>
         <note>Save button label</note>
       </trans-unit>
-      <trans-unit id="SearchEngine.addEngineError" xml:space="preserve">
+      <trans-unit id="SearchEngine.addEngineError">
         <source>That didn't work. Try replacing the search term with this: %s.</source>
         <target>Це не спрацювало. Спробуйте змінити пошуковий запит цим: %s.</target>
         <note>Label for error state when entering an invalid search engine URL. %s is a search term in a URL.</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptDisable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptDisable">
         <source>No</source>
         <target>Ні</target>
         <note>Label for disable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptEnable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptEnable">
         <source>Yes</source>
         <target>Так</target>
         <note>Label for enable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptMessage" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptMessage">
         <source>To get suggestions, %@ needs to send what you type in the address bar to the search engine.</source>
         <target>Для отримання пропозицій %@ повинен відправляти введений в адресному рядку текст провайдеру пошуку.</target>
         <note>%@ is the name of the app (Focus / Klar). Label for search suggestions prompt message</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptTitle" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptTitle">
         <source>Show Search Suggestions?</source>
         <target>Показувати пошукові пропозиції?</target>
         <note>Title for search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButton" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButton">
         <source>Add Another Search Engine</source>
         <target>Додати інший засіб пошуку</target>
         <note>Text for button to add another search engine in settings</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus">
         <source>+ Add Another Search Engine</source>
         <target>+ Додати інший засіб пошуку</target>
         <note>Text for button to add another search engine in settings with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineTitle" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineTitle">
         <source>Add Search Engine</source>
         <target>Додати засіб пошуку</target>
         <note>Title on add search engine settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.InstalledSearchEngines" xml:space="preserve">
+      <trans-unit id="Settings.Search.InstalledSearchEngines">
         <source>INSTALLED SEARCH ENGINES</source>
         <target>ВСТАНОВЛЕНІ ЗАСОБИ ПОШУКУ</target>
         <note>Header for rows of installed search engines</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NameToDisplay" xml:space="preserve">
+      <trans-unit id="Settings.Search.NameToDisplay">
         <source>Name to display</source>
         <target>Назва для показу</target>
         <note>Label for input field for the name of the search engine to be added</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NewSearchEngineAdded" xml:space="preserve">
+      <trans-unit id="Settings.Search.NewSearchEngineAdded">
         <source>New Search Engine Added.</source>
         <target>Новий засіб пошуку додано.</target>
         <note>Toast displayed after adding a search engine</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.RestoreEngine" xml:space="preserve">
+      <trans-unit id="Settings.Search.RestoreEngine">
         <source>Restore Default Search Engines</source>
         <target>Відновити типові засоби пошуку</target>
         <note>Label for button to bring deleted default engines back</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchEngineName" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchEngineName">
         <source>Search engine name</source>
         <target>Назва засобу пошуку</target>
         <note>Placeholder text for input of new search engine name</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplate" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplate">
         <source>Search string to use</source>
         <target>Запит для пошуку</target>
         <note>Label for input of search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplatePlaceholder" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplatePlaceholder">
         <source>Paste or enter search string. If necessary, replace search term with: %s.</source>
         <target>Вставте або введіть запит для пошуку. Якщо необхідно, замініть пошуковий термін на: %s.</target>
         <note>Placeholder text for input of new search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.autocompleteSection" xml:space="preserve">
+      <trans-unit id="Settings.autocompleteSection">
         <source>URL Autocomplete</source>
         <target>Автозавершення URL</target>
         <note>Title for the URL Autocomplete row</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherMessage" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherMessage">
         <source>Blocking other content trackers may break some videos and web pages.</source>
         <target>Блокування інших елементів стеження може пошкодити деякі відео і веб-сторінки.</target>
         <note>Alert message shown when toggling the Content blocker</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherNo2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherNo2">
         <source>Cancel</source>
         <target>Скасувати</target>
         <note>Button label for declining Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherYes2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherYes2">
         <source>Block Content Trackers</source>
         <target>Блокувати стеження вмісту</target>
         <note>Button label for accepting Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSearchSuggestion" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSearchSuggestion">
         <source>%@ will send what you type in the address bar to your search engine.</source>
         <target>%@ відправлятиме провайдеру пошуку текст, введений в адресному рядку.</target>
         <note>Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSendUsageData">
         <source>Mozilla strives to collect only what we need to provide and improve %@ for everyone.</source>
         <target>Mozilla зобов'язується збирати лише дані, що необхідні для роботи і вдосконалення %@.</target>
         <note>Description associated to the Send Usage Data toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.learnMore" xml:space="preserve">
+      <trans-unit id="Settings.learnMore">
         <source>Learn more.</source>
         <target>Докладніше.</target>
         <note>Subtitle for Send Anonymous Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.rate" xml:space="preserve">
+      <trans-unit id="Settings.rate">
         <source>Rate %@</source>
         <target>Оцінити %@</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, allows the user to leave a review for the app on the app store.</note>
       </trans-unit>
-      <trans-unit id="Settings.safariTitle" xml:space="preserve">
+      <trans-unit id="Settings.safariTitle">
         <source>SAFARI INTEGRATION</source>
         <target>ІНТЕГРАЦІЯ SAFARI</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.screenTitle" xml:space="preserve">
+      <trans-unit id="Settings.screenTitle">
         <source>Settings</source>
         <target>Параметри</target>
         <note>Title for settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchLabel" xml:space="preserve">
+      <trans-unit id="Settings.searchLabel">
         <source>Search Engine</source>
         <target>Засіб пошуку</target>
         <note>Label for the search engine in the search screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchSuggestions" xml:space="preserve">
+      <trans-unit id="Settings.searchSuggestions">
         <source>Get Search Suggestions</source>
         <target>Отримувати пошукові пропозиції</target>
         <note>Label for the Search Suggestions toggle row</note>
       </trans-unit>
-      <trans-unit id="Settings.searchTitle2" xml:space="preserve">
+      <trans-unit id="Settings.searchTitle2">
         <source>SEARCH</source>
         <target>ПОШУК</target>
         <note>Title for the search selection screen</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionIntegration" xml:space="preserve">
+      <trans-unit id="Settings.sectionIntegration">
         <source>INTEGRATION</source>
         <target>ІНТЕГРАЦІЯ</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionMozilla" xml:space="preserve">
+      <trans-unit id="Settings.sectionMozilla">
         <source>MOZILLA</source>
         <target>MOZILLA</target>
         <note>Section label for Mozilla toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPerformance" xml:space="preserve">
+      <trans-unit id="Settings.sectionPerformance">
         <source>PERFORMANCE</source>
         <target>ШВИДКОДІЯ</target>
         <note>Section label for performance toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPrivacy" xml:space="preserve">
+      <trans-unit id="Settings.sectionPrivacy">
         <source>PRIVACY</source>
         <target>ПРИВАТНІСТЬ</target>
         <note>Section label for privacy toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionSecurity" xml:space="preserve">
+      <trans-unit id="Settings.sectionSecurity">
         <source>SECURITY</source>
         <target>БЕЗПЕКА</target>
         <note>Header label for security toggles displayed in the settings menu</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAds2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAds2">
         <source>Advertising</source>
         <target>Реклама</target>
         <note>Label for the checkbox to toggle Advertising trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAnalytics2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAnalytics2">
         <source>Analytics</source>
         <target>Аналітика</target>
         <note>Label for the checkbox to toggle Analytics trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockFonts" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockFonts">
         <source>Block web fonts</source>
         <target>Блокувати веб-шрифти</target>
         <note>Label for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockOther2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockOther2">
         <source>Content</source>
         <target>Вміст</target>
         <note>Label for the checkbox to toggle Other trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockSocial2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockSocial2">
         <source>Social</source>
         <target>Соціальні мережі</target>
         <note>Label for the checkbox to toggle Social trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceID" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceID">
         <source>Use Face ID to unlock app</source>
         <target>Використовувати Face ID для розблокування програми</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceIDDescription">
         <source>Face ID can unlock %@ if a URL is already open in the app</source>
         <target>Face ID може розблокувати %@ якщо URL-адреса вже відкрита в програмі</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Face ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleHomeScreenTips" xml:space="preserve">
+      <trans-unit id="Settings.toggleHomeScreenTips">
         <source>Show home screen tips</source>
         <target>Показувати поради на головному екрані</target>
         <note>Show home screen tips toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleOtherSubtitle" xml:space="preserve">
+      <trans-unit id="Settings.toggleOtherSubtitle">
         <source>May break some videos and Web pages</source>
         <target>Може пошкодити деякі відео і веб-сторінки</target>
         <note>Label subtitle for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSafari" xml:space="preserve">
+      <trans-unit id="Settings.toggleSafari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Safari toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.toggleSendUsageData">
         <source>Send usage data</source>
         <target>Надсилати дані про використання</target>
         <note>Label for Send Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchID" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchID">
         <source>Use Touch ID to unlock app</source>
         <target>Використовувати Touch ID для розблокування програми</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchIDDescription">
         <source>Touch ID can unlock %@ if a URL is already open in the app</source>
         <target>Touch ID може розблокувати %@ якщо URL-адреса вже відкрита в програмі</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Touch ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOff" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOff">
         <source>Off</source>
         <target>Вимкнено</target>
         <note>Status off for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOn" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOn">
         <source>On</source>
         <target>Увімкнено</target>
         <note>Status on for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.whatsNewTitle" xml:space="preserve">
+      <trans-unit id="Settings.whatsNewTitle">
         <source>What’s New</source>
         <target>Що нового</target>
         <note>Title for What's new screen</note>
       </trans-unit>
-      <trans-unit id="Settinsg.siriShortcutsTitle" xml:space="preserve">
+      <trans-unit id="Settinsg.siriShortcutsTitle">
         <source>SIRI SHORTCUTS</source>
         <target>ШВИДКІ КОМАНДИ SIRI</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.FindInPage" xml:space="preserve">
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Знайти на сторінці</target>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.GetFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.GetFirefox">
         <source>Get the Firefox App</source>
         <target>Отримати Firefox</target>
         <note>Text for the share menu option when a user wants to open a page in Firefox but doesn’t have it installed. This string will not wrap in the interface. Instead, it will truncate. To prevent this, please keep the localized string to 18 or fewer characters. If your string runs longer than 18 characters, you can use 'Get Firefox' as the basis for your string. However, if at all possible, we’d like to signal to the user that they will be going to the App Store and installing the application from there. That is why we are using Get and App in the en-US string.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.PageActions" xml:space="preserve">
+      <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <target>Дії сторінки</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestDesktop" xml:space="preserve">
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
         <target>Повна версія сайту</target>
         <note>Text for the share menu option when a user wants to reload the site as a desktop</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestMobile" xml:space="preserve">
+      <trans-unit id="ShareMenu.RequestMobile">
         <source>Request Mobile Site</source>
         <target>Мобільна версія сайту</target>
         <note>Text for the share menu option when a user wants to reload the site as a mobile device</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenChrome" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenChrome">
         <source>Open in Chrome</source>
         <target>Відкрити в Chrome</target>
         <note>Text for the share menu option when a user wants to open the current website in the Chrome app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenFirefox">
         <source>Open in Firefox</source>
         <target>Відкрити в Firefox</target>
         <note>Text for the share menu option when a user wants to open the current website in the Firefox app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenSafari" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenSafari">
         <source>Open in Safari</source>
         <target>Відкрити в Safari</target>
         <note>Text for the share menu option when a user wants to open the current website in the Safari app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.SharePage" xml:space="preserve">
+      <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <target>Поділитися сторінкою...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
       </trans-unit>
-      <trans-unit id="Siri.add" xml:space="preserve">
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
+      </trans-unit>
+      <trans-unit id="Siri.add">
         <source>Add</source>
         <target>Додати</target>
         <note>Button to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.addTo" xml:space="preserve">
+      <trans-unit id="Siri.addTo">
         <source>Add to Siri</source>
         <target>Додати до Siri</target>
         <note>Button to add a specified shortcut option to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.editOpenUrl" xml:space="preserve">
+      <trans-unit id="Siri.editOpenUrl">
         <source>Re-Record or Delete Shortcut</source>
         <target>Перезаписати чи видалити швидку команду</target>
         <note>Label for button to edit the Siri phrase or delete the Siri functionality.</note>
       </trans-unit>
-      <trans-unit id="Siri.erase" xml:space="preserve">
+      <trans-unit id="Siri.erase">
         <source>Erase</source>
         <target>Стерти</target>
         <note>Title of option in settings to set up Siri to erase</note>
       </trans-unit>
-      <trans-unit id="Siri.eraseAndOpen" xml:space="preserve">
+      <trans-unit id="Siri.eraseAndOpen">
         <source>Erase &amp; Open</source>
         <target>Стерти і відкрити</target>
         <note>Title of option in settings to set up Siri to erase and then open the app.</note>
       </trans-unit>
-      <trans-unit id="Siri.favoriteUrl" xml:space="preserve">
+      <trans-unit id="Siri.favoriteUrl">
         <source>Open Favorite Site</source>
         <target>Відкрити улюблений сайт</target>
         <note>Title for screen to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.openURL" xml:space="preserve">
+      <trans-unit id="Siri.openURL">
         <source>Open Favorite Site</source>
         <target>Відкрити улюблений сайт</target>
         <note>Title of option in settings to set up Siri to open a specified URL in Focus/Klar.</note>
       </trans-unit>
-      <trans-unit id="Siri.urlToOpen" xml:space="preserve">
+      <trans-unit id="Siri.urlToOpen">
         <source>URL to open</source>
         <target>Відкрити URL</target>
         <note>Label for input to set a favorite URL to be opened by Siri.</note>
       </trans-unit>
-      <trans-unit id="URL.addToAutocompleteLabel" xml:space="preserve">
+      <trans-unit id="URL.addToAutocompleteLabel">
         <source>Add link to autocomplete</source>
         <target>Додати посилання для автозавершення</target>
         <note>Label displayed for button used as a shortcut to add a link to the list of URLs to autocomplete.</note>
       </trans-unit>
-      <trans-unit id="URL.cancelLabel" xml:space="preserve">
+      <trans-unit id="URL.cancelLabel">
         <source>Cancel</source>
         <target>Скасувати</target>
         <note>Label for cancel button shown when entering a URL or search</note>
       </trans-unit>
-      <trans-unit id="URL.contextMenu" xml:space="preserve">
+      <trans-unit id="URL.contextMenu">
         <source>Paste &amp; Go</source>
         <target>Вставити і перейти</target>
         <note>Text for the URL context menu when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.eraseButtonLabel" xml:space="preserve">
+      <trans-unit id="URL.eraseButtonLabel">
         <source>ERASE</source>
         <target>СТЕРТИ</target>
         <note>Erase button in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.eraseMessageLabel2" xml:space="preserve">
+      <trans-unit id="URL.eraseMessageLabel2">
         <source>Browsing history cleared</source>
         <target>Історію перегляду очищено</target>
         <note>Message shown after pressing the Erase button</note>
       </trans-unit>
-      <trans-unit id="URL.findOnPageLabel" xml:space="preserve">
+      <trans-unit id="URL.findOnPageLabel">
         <source>Find in page: %@</source>
         <target>Знайти на сторінці: %@</target>
         <note>Label displayed for find in page button when typing in the URL Bar. %@ is any text the user has typed into the URL bar that they want to find on the current page.</note>
       </trans-unit>
-      <trans-unit id="URL.paste" xml:space="preserve">
+      <trans-unit id="URL.paste">
         <source>Paste</source>
         <target>Вставити</target>
         <note>Text for a menu displayed from the bottom of the screen when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.placeholderText" xml:space="preserve">
+      <trans-unit id="URL.placeholderText">
         <source>Search or enter address</source>
         <target>Введіть запит чи адресу</target>
         <note>Placeholder text shown in the URL bar before the user navigates to a page</note>
       </trans-unit>
-      <trans-unit id="URL.searchLabel" xml:space="preserve">
+      <trans-unit id="URL.searchLabel">
         <source>Search for %@</source>
         <target>Шукати %@</target>
         <note>Label displayed for search button when typing in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="URL.trackersBlockedLabel">
         <source>Trackers blocked</source>
         <target>Заблоковано стеження</target>
         <note>Text for the URL bar showing the number of trackers blocked on a webpage.</note>
       </trans-unit>
-      <trans-unit id="actionSheet.openIn" xml:space="preserve">
+      <trans-unit id="actionSheet.openIn">
         <source>Open in %@</source>
         <target>Відкрити в %@</target>
         <note>Title for action sheet item to open the current page in another application. Placeholder is the name of the application to open the current page.</note>
       </trans-unit>
-      <trans-unit id="browser.copyAddressToast" xml:space="preserve">
+      <trans-unit id="browser.copyAddressToast">
         <source>URL Copied To Clipboard</source>
         <target>URL скопійовано в буфер обміну</target>
         <note>Toast displayed after a URL has been copied to the clipboard</note>
       </trans-unit>
-      <trans-unit id="browserShortcutDescription.selectLocationBar" xml:space="preserve">
+      <trans-unit id="browserShortcutDescription.selectLocationBar">
         <source>Select Location Bar</source>
         <target>Виберіть панель адреси</target>
         <note>Label to display in the Discoverability overlay for keyboard shortcuts</note>
       </trans-unit>
-      <trans-unit id="contextMenu.clipboardLink" xml:space="preserve">
+      <trans-unit id="contextMenu.clipboardLink">
         <source>Link you copied: %@</source>
         <target>Ваше скопійоване посилання: %@</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.copyImageTitle">
         <source>Copy Image</source>
         <target>Копіювати зображення</target>
         <note>Text for the context menu when a user wants to copy an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyLink" xml:space="preserve">
+      <trans-unit id="contextMenu.copyLink">
         <source>Copy Link</source>
         <target>Копіювати посилання</target>
         <note>Text for the context menu when a user wants to copy a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.linkCopied" xml:space="preserve">
+      <trans-unit id="contextMenu.linkCopied">
         <source>Link you copied: </source>
         <target>Ваше скопійоване посилання:</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.saveImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.saveImageTitle">
         <source>Save Image</source>
         <target>Зберегти зображення</target>
         <note>Text for the context menu when a user wants to save an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.shareLinkTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.shareLinkTitle">
         <source>Share Link</source>
         <target>Поділитись посиланням</target>
         <note>Text for the context menu when a user wants to share a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="externalAppLinkWithAppName.messageTitle" xml:space="preserve">
+      <trans-unit id="externalAppLinkWithAppName.messageTitle">
         <source>%1$@ wants to open %2$@</source>
         <target>%1$@ хоче відкрити %2$@</target>
         <note>Dialog title used for opening an external app from Focus. First placeholder string is the app name of either Focus or Klar and the second placeholder string specifies the app it wants to open.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.description" xml:space="preserve">
+      <trans-unit id="photosPermission.description">
         <source>This lets you save images to your Camera Roll</source>
         <target>Це дозволяє вам зберігати зображення до своєї фотоплівки</target>
         <note>Description for dialog used for requesting a user to enable access to Photos.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.openSettings" xml:space="preserve">
+      <trans-unit id="photosPermission.openSettings">
         <source>Open Settings</source>
         <target>Відкрити параметри</target>
         <note>Title for button that takes the user to system settings</note>
       </trans-unit>
-      <trans-unit id="photosPermission.title" xml:space="preserve">
+      <trans-unit id="photosPermission.title">
         <source>“%@” Would Like to Access Your Photos</source>
         <target>“%@” бажає отримати доступ до ваших фотографій</target>
         <note>Dialog title used for requesting a user to enable access to Photos. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="settings.Search.SearchTemplateExample" xml:space="preserve">
+      <trans-unit id="settings.Search.SearchTemplateExample">
         <source>Example: searchengineexample.com/search/?q=%s</source>
         <target>Зразок: searchengineexample.com/search/?q=%s</target>
         <note>Text displayed as an example of the template to add a search engine.</note>
       </trans-unit>
-      <trans-unit id="share" xml:space="preserve">
+      <trans-unit id="share">
         <source>Share</source>
         <target>Поділитися</target>
         <note>Text for a share button</note>
       </trans-unit>
-      <trans-unit id="shareMenu.copyAddress" xml:space="preserve">
+      <trans-unit id="shareMenu.copyAddress">
         <source>Copy Address</source>
         <target>Копіювати адресу</target>
         <note>Text for the share menu when a user wants to copy a URL.</note>
       </trans-unit>
-      <trans-unit id="touchId.reason" xml:space="preserve">
+      <trans-unit id="touchId.reason">
         <source>Use Touch ID to return to %@</source>
         <target>Використовувати Touch ID для повернення до %@</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.adTrackersLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.adTrackersLabel">
         <source>Ad trackers</source>
         <target>Стеження реклами</target>
         <note>Label for ad trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.analyticTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.analyticTrackerLabel">
         <source>Analytic trackers</source>
         <target>Стеження аналітики</target>
         <note>label for analytic trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.contentTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>
         <target>Стеження вмісту</target>
         <note>label for content trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.disabledLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.disabledLabel">
         <source>Tracking Protection off</source>
         <target>Захист від стеження вимкнено</target>
         <note>text showing the tracking protection is disabled.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.label" xml:space="preserve">
+      <trans-unit id="trackingProtection.label">
         <source>Tracking Protection</source>
         <target>Захист від стеження</target>
         <note>Title for the tracking settings page to change what trackers are blocked.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.labelDescription" xml:space="preserve">
+      <trans-unit id="trackingProtection.labelDescription">
         <source>Turning this off may fix some site problems</source>
         <target>Вимкнення цієї функції може вирішити деякі проблеми з сайтом</target>
         <note>Description/subtitle for the tracking protection label.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.learnMore" xml:space="preserve">
+      <trans-unit id="trackingProtection.learnMore">
         <source>Learn More</source>
         <target>Докладніше</target>
         <note>Text for the button to learn more about Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.moreSettings" xml:space="preserve">
+      <trans-unit id="trackingProtection.moreSettings">
         <source>More Settings</source>
         <target>Інші параметри</target>
         <note>Text for the button that closes the Shield Data and opens the regular Settings screen.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.socialTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.socialTrackerLabel">
         <source>Social trackers</source>
         <target>Стеження соціальних мереж</target>
         <note>label for social trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOff" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOff">
         <source>Protections are OFF for this session</source>
         <target>Захист вимкнено для цього сеансу</target>
         <note>Text for the status off from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOn" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOn">
         <source>Protections are ON for this session</source>
         <target>Захист увімкнено для цього сеансу</target>
         <note>Text for the status on from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleDescription1" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleDescription1">
         <source>Disable until you close %@ or tap ERASE.</source>
         <target>Вимкнути до закриття %@, або оберіть СТЕРТИ.</target>
         <note>Description for the tracking protection toggle. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleLabel2">
         <source>Enhanced Tracking Protection</source>
         <target>Розширений захист від стеження</target>
         <note>Text for the toggle that enables/disables tracking protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackerDescriptionLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackerDescriptionLabel2">
         <source>Keep your data to yourself. %@ protects you from many of the most common trackers that follow what you do online.</source>
         <target>Зберігайте свої дані при собі. %@ захищає вас від численних найпоширеніших елементів стеження, що переслідують вас в мережі.</target>
         <note>General description of tracking protection settings, which is displayed underneath the trackers preferences in Settings. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersBlockedLabel">
         <source>Trackers blocked since %@</source>
         <target>Заблоковано стеження, починаючи з %@</target>
         <note>Text for tracking protection screen showing the number of trackers blocked since the app install. The placeholder is replaced with the install date of the application.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersHeader" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersHeader">
         <source>Trackers and scripts to block</source>
         <target>Блокувати стеження й скрипти</target>
         <note>Text for the header of trackers section from Tracking Protection.</note>
       </trans-unit>
     </body>
   </file>
-  <file original="Blockzilla/Settings.bundle/en.lproj/Root.strings" datatype="plaintext" source-language="en" target-language="uk">
+  <file original="Blockzilla/Settings.bundle/en.lproj/Root.strings" source-language="en" target-language="uk" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="SettingsBundle.Licenses" xml:space="preserve">
+      <trans-unit id="SettingsBundle.Licenses">
         <source>Licenses</source>
         <target>Ліцензії</target>
         <note>The title of the Licenses setting in the settings that Focus shows in the global iOS Settings app.</note>
@@ -1086,3 +1105,4 @@
     </body>
   </file>
 </xliff>
+

--- a/ur/focus-ios.xliff
+++ b/ur/focus-ios.xliff
@@ -743,6 +743,10 @@
         <target>SIRI SHORTCUTS</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>صفحے میں ڈھونڈیں</target>
@@ -757,6 +761,10 @@
         <source>Page Actions</source>
         <target>صفحہ اعمال</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -787,6 +795,10 @@
         <source>Share Page With...</source>
         <target>…کے ساتھ صفحہ شیئر کریں</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -967,6 +979,14 @@
         <source>Analytic trackers</source>
         <target>تجزیاتی ٹریکررز</target>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/uz/focus-ios.xliff
+++ b/uz/focus-ios.xliff
@@ -671,6 +671,10 @@
         <source>SIRI SHORTCUTS</source>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
       <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
@@ -682,6 +686,10 @@
       <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
       <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
@@ -706,6 +714,10 @@
       <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
+      </trans-unit>
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
       </trans-unit>
       <trans-unit id="Siri.add">
         <source>Add</source>
@@ -858,6 +870,14 @@
       <trans-unit id="trackingProtection.analyticTrackerLabel">
         <source>Analytic trackers</source>
         <note>label for analytic trackers.</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
       </trans-unit>
       <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>

--- a/vi/focus-ios.xliff
+++ b/vi/focus-ios.xliff
@@ -1,36 +1,35 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Blockzilla/en.lproj/InfoPlist.strings" source-language="en" target-language="vi" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="NSCameraUsageDescription" xml:space="preserve">
+      <trans-unit id="NSCameraUsageDescription">
         <source>This lets you take and upload photos.</source>
         <target>Điều này cho phép bạn chụp và tải hình ảnh lên.</target>
         <note>Privacy - Camera Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSFaceIDUsageDescription" xml:space="preserve">
+      <trans-unit id="NSFaceIDUsageDescription">
         <source>This lets you unlock the app.</source>
         <target>Điều này cho phép bạn mở khóa ứng dụng.</target>
         <note>Privacy - Face ID Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSLocationWhenInUseUsageDescription" xml:space="preserve">
+      <trans-unit id="NSLocationWhenInUseUsageDescription">
         <source>Websites you visit may request your location.</source>
         <target>Trang web bạn truy cập có thể yêu cầu vị trí của bạn.</target>
         <note>Privacy - Location When In Use Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSMicrophoneUsageDescription" xml:space="preserve">
+      <trans-unit id="NSMicrophoneUsageDescription">
         <source>This lets you take and upload videos.</source>
         <target>Điều này cho phép bạn quay và tải video lên.</target>
         <note>Privacy - Microphone Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSPhotoLibraryAddUsageDescription" xml:space="preserve">
+      <trans-unit id="NSPhotoLibraryAddUsageDescription">
         <source>This lets you save and upload photos.</source>
         <target>Điều này cho phép bạn lưu và tải hình ảnh lên.</target>
         <note>Privacy - Photo Library Additions Usage Description</note>
       </trans-unit>
-      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen" xml:space="preserve">
+      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen">
         <source>Erase and Open</source>
         <target>Xóa và mở</target>
         <note>This is the menu item that appears when you long press the Focus icon on the phone home screen.</note>
@@ -42,7 +41,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intents.Erase.Title" xml:space="preserve">
+      <trans-unit id="Intents.Erase.Title">
         <source>Erase</source>
         <target>Xóa</target>
         <note>Title of the Erase intent.</note>
@@ -54,42 +53,42 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intro.Slides.History.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Description">
         <source>Clear your entire browsing session history, passwords, cookies anytime with a single tap.</source>
         <target>Xóa toàn bộ lịch sử duyệt web, mật khẩu, cookie bất kỳ lúc nào chỉ với một cú chạm.</target>
         <note>Description for the 'History' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.History.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Title">
         <source>Your history is history</source>
         <target>Lịch sử của bạn đã là quá khứ</target>
         <note>Title for the third  panel 'History' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Next.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Next.Button">
         <source>Next</source>
         <target>Tiếp theo</target>
         <note>Button to go to the next card in Focus onboarding.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Description">
         <source>Searching for something different? Choose a different search engine.</source>
         <target>Bạn đang tìm kiếm một thứ khác? Hãy chọn một công cụ tìm kiếm khác.</target>
         <note>Description for the 'Favorite Search Engine' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Title">
         <source>Your search, your way</source>
         <target>Tìm kiếm của bạn, theo cách của bạn</target>
         <note>Title for the second  panel 'Search' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Skip.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Skip.Button">
         <source>Skip</source>
         <target>Bỏ qua</target>
         <note>Button to skip onboarding in Focus</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Description">
         <source>Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times.</source>
         <target>Duyệt web ở chế độ riêng tư để nâng cao bảo mật. Giúp làm giảm thời gian tải trang và chặn các quảng cáo và nội dung mà có thể theo dõi bạn trên các trang web.</target>
         <note>Description for the 'Welcome' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Title">
         <source>Power up your privacy</source>
         <target>Tăng quyền riêng tư của bạn</target>
         <note>Title for the first panel 'Welcome' in the First Run tour.</note>
@@ -101,967 +100,987 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="About.learnMoreButton" xml:space="preserve">
+      <trans-unit id="About.learnMoreButton">
         <source>Learn more</source>
         <target>Tìm hiểu thêm</target>
         <note>Button on About screen</note>
       </trans-unit>
-      <trans-unit id="About.missionLabel" xml:space="preserve">
+      <trans-unit id="About.missionLabel">
         <source>%@ is produced by Mozilla. Our mission is to foster a healthy, open Internet.</source>
         <target>%@ được sản xuất bởi Mozilla. Nhiệm vụ của chúng tôi là thúc đẩy một Internet lành mạnh, cởi mở.</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet1" xml:space="preserve">
+      <trans-unit id="About.privateBullet1">
         <source>Search and browse right in the app</source>
         <target>Tìm kiếm và duyệt ngay trong ứng dụng</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet2" xml:space="preserve">
+      <trans-unit id="About.privateBullet2">
         <source>Block trackers (or update settings to allow trackers)</source>
         <target>Chặn trình theo dõi (hoặc cập nhật cài đặt để cho phép trình theo dõi)</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet3" xml:space="preserve">
+      <trans-unit id="About.privateBullet3">
         <source>Erase to delete cookies as well as search and browsing history</source>
         <target>Xóa cookie cũng như lịch sử tìm kiếm và duyệt web khi xong phiên làm việc</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBulletHeader" xml:space="preserve">
+      <trans-unit id="About.privateBulletHeader">
         <source>Use it as a private browser:</source>
         <target>Sử dụng nó như trình duyệt riêng tư:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowHelp" xml:space="preserve">
+      <trans-unit id="About.rowHelp">
         <source>Help</source>
         <target>Trợ giúp</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowPrivacy" xml:space="preserve">
+      <trans-unit id="About.rowPrivacy">
         <source>Privacy Notice</source>
         <target>Chính sách riêng tư</target>
         <note>Link to Privacy Notice in the About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowRights" xml:space="preserve">
+      <trans-unit id="About.rowRights">
         <source>Your Rights</source>
         <target>Quyền lợi của bạn</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet1" xml:space="preserve">
+      <trans-unit id="About.safariBullet1">
         <source>Block trackers for improved privacy</source>
         <target>Chặn trình theo dõi để cải thiện sự riêng tư</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet2" xml:space="preserve">
+      <trans-unit id="About.safariBullet2">
         <source>Block web fonts to reduce page size</source>
         <target>Chặn phông chữ Web để giảm kích thước trang</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBulletHeader" xml:space="preserve">
+      <trans-unit id="About.safariBulletHeader">
         <source>Use it as a Safari extension:</source>
         <target>Sử dụng nó như phần mở rộng của Safari:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.title" xml:space="preserve">
+      <trans-unit id="About.title">
         <source>About %@</source>
         <target>Giới thiệu %@</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, takes the user to a page with information about the product. Also displayed as a header for the About page.</note>
       </trans-unit>
-      <trans-unit id="About.topLabel" xml:space="preserve">
+      <trans-unit id="About.topLabel">
         <source>%@ puts you in control.</source>
         <target>%@ giúp bạn kiểm soát.</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Dismiss" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Dismiss">
         <source>Ok</source>
         <target>Ok</target>
         <note>Button to dismiss the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Message" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Message">
         <source>An error occured while adding the pass to Wallet. Please try again later.</source>
         <target>Đã xảy ra lỗi trong khi thêm thẻ vào Wallet. Vui lòng thử lại sau.</target>
         <note>Message of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Title" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Title">
         <source>Failed to Add Pass</source>
         <target>Thất bại khi thêm thẻ</target>
         <note>Title of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="Authentication.reason" xml:space="preserve">
+      <trans-unit id="Authentication.reason">
         <source>Authenticate to return to %@</source>
         <target>Xác thực để quay lại %@</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID, Face ID, or passcode to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrl">
         <source>Add Custom URL</source>
         <target>Thêm URL tùy chỉnh</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlError" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlError">
         <source>Double-check the URL you entered.</source>
         <target>Kiểm tra lại URL mà bạn đã nhập.</target>
         <note>Label for error state when entering an invalid URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlExample" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlExample">
         <source>Example: example.com</source>
         <target>Ví dụ: example.com</target>
         <note>A label displaying an example URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlLabel">
         <source>URL to add</source>
         <target>URL muốn thêm</target>
         <note>Label for the input to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlPlaceholder" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlPlaceholder">
         <source>Paste or enter URL</source>
         <target>Dán hoặc nhập URL</target>
         <note>Placeholder for the input field to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlWithPlus" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlWithPlus">
         <source>+ Add Custom URL</source>
         <target>+ Thêm URL tùy chỉnh</target>
         <note>Label for button to add a custom URL with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.customDescriptoin">
         <source>Add and manage custom autocomplete URLs.</source>
         <target>Thêm và quản lý các URL tùy chỉnh tự động điền.</target>
         <note>Description for adding and managing custom autocomplete URLs</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.customLabel">
         <source>Custom URLs</source>
         <target>URL tùy chỉnh</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.customTitle">
         <source>CUSTOM URL LIST</source>
         <target>DANH SÁCH URL TÙY CHỈNH</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customUrlAdded" xml:space="preserve">
+      <trans-unit id="Autocomplete.customUrlAdded">
         <source>New Custom URL added.</source>
         <target>URL tùy chỉnh mới đã được thêm vào.</target>
         <note>Label for toast alerting a custom URL has been added</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultDescriptoin">
         <source>Enable to have %@ autocomplete over 450 popular URLs in the address bar.</source>
         <target>Cho phép tự đồng điền %@ trên 450 URL phổ biến trên thanh địa chỉ.</target>
         <note>Description for enabling or disabling the default list. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultLabel">
         <source>Autocomplete</source>
         <target>Tự động điền</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultTitle">
         <source>DEFAULT URL LIST</source>
         <target>DANH SÁCH URL MẶC ĐỊNH</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.disabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.disabled">
         <source>Disabled</source>
         <target>Đã tắt</target>
         <note>label describing URL Autocomplete as disabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.duplicateUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.duplicateUrl">
         <source>URL already exists</source>
         <target>URL đã tồn tại</target>
         <note>Label for toast alerting that the custom URL being added is a duplicate</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.emptyState" xml:space="preserve">
+      <trans-unit id="Autocomplete.emptyState">
         <source>No Custom URLs to display</source>
         <target>Không có URL tùy chỉnh nào được hiển thị</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.enabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.enabled">
         <source>Enabled</source>
         <target>Đã bật</target>
         <note>label describing URL Autocomplete as enabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.manageSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.manageSites">
         <source>Manage Sites</source>
         <target>Quản lý trang web</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySites" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySites">
         <source>My Sites</source>
         <target>Các trang web của tôi</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySitesDesc" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySitesDesc">
         <source>Enable to have %@ autocomplete your favorite URLs.</source>
         <target>Bật để %@ tự động hoàn thành các URL yêu thích của bạn.</target>
         <note>Description for adding and managing custom autocomplete URLs. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.topSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.topSites">
         <source>Top Sites</source>
         <target>Các trang web hàng đầu</target>
         <note>Label for enabling or disabling top sites</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.newSession" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.newSession">
         <source>New Session</source>
         <target>Phiên mới</target>
         <note>Create a new session after failing a biometric check</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.reason" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.reason">
         <source>Unlock %@ when re-opening in order to prevent unauthorized access.</source>
         <target>Mở khóa %@ khi mở lại để ngăn chặn truy cập trái phép.</target>
         <note>%@ is app name. Explanation for why the app needs access to biometric information. Prompt is only shown once when the user first tries to enable Face ID to open the app.</note>
       </trans-unit>
-      <trans-unit id="Browser.backLabel" xml:space="preserve">
+      <trans-unit id="Browser.backLabel">
         <source>Back</source>
         <target>Quay lại</target>
         <note>Accessibility label for the back button</note>
       </trans-unit>
-      <trans-unit id="Browser.copyAddressLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyAddressLabel">
         <source>Copy Address</source>
         <target>Sao chép địa chỉ liên kết</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.copyMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyMenuLabel">
         <source>Copy</source>
         <target>Sao chép</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.customURLMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.customURLMenuLabel">
         <source>Add Custom URL</source>
         <target>Thêm URL tùy chỉnh</target>
         <note>Custom URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.forwardLabel" xml:space="preserve">
+      <trans-unit id="Browser.forwardLabel">
         <source>Forward</source>
         <target>Tiếp theo</target>
         <note>Accessibility label for the forward button</note>
       </trans-unit>
-      <trans-unit id="Browser.reloadLabel" xml:space="preserve">
+      <trans-unit id="Browser.reloadLabel">
         <source>Reload</source>
         <target>Tải lại</target>
         <note>Accessibility label for the reload button</note>
       </trans-unit>
-      <trans-unit id="Browser.settingsLabel" xml:space="preserve">
+      <trans-unit id="Browser.settingsLabel">
         <source>Settings</source>
         <target>Thiết lập</target>
         <note>Accessibility label for the settings button</note>
       </trans-unit>
-      <trans-unit id="Browser.shareLabel" xml:space="preserve">
+      <trans-unit id="Browser.shareLabel">
         <source>Share</source>
         <target>Chia sẻ</target>
         <note>Accessibility label for the share button</note>
       </trans-unit>
-      <trans-unit id="Browser.stopLabel" xml:space="preserve">
+      <trans-unit id="Browser.stopLabel">
         <source>Stop</source>
         <target>Dừng</target>
         <note>Accessibility label for the stop button</note>
       </trans-unit>
-      <trans-unit id="Cancel" xml:space="preserve">
+      <trans-unit id="Cancel">
         <source>Cancel</source>
         <target>Hủy bỏ</target>
         <note>Label on button to cancel edits</note>
       </trans-unit>
-      <trans-unit id="Done" xml:space="preserve">
+      <trans-unit id="Done">
         <source>Done</source>
         <target>Xong</target>
         <note>Label on button to complete edits</note>
       </trans-unit>
-      <trans-unit id="Edit" xml:space="preserve">
+      <trans-unit id="Edit">
         <source>Edit</source>
         <target>Chỉnh sửa</target>
         <note>Label on button to allow edits</note>
       </trans-unit>
-      <trans-unit id="Error.tryAgainButton" xml:space="preserve">
+      <trans-unit id="Error.tryAgainButton">
         <source>Try again</source>
         <target>Thử lại</target>
         <note>Button label to reload the error page</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.cancelTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.cancelTitle">
         <source>Cancel</source>
         <target>Hủy bỏ</target>
         <note>Button label used for cancelling to open another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.messageTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.messageTitle">
         <source>%@ wants to open another App</source>
         <target>%@ muốn mở Ứng dụng khác</target>
         <note>Dialog title used for opening an external app from Focus. The placeholder string is the app name of either Focus or Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.openTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.openTitle">
         <source>Open</source>
         <target>Mở</target>
         <note>Button label for opening another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.callButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.callButton">
         <source>Call</source>
         <target>Gọi</target>
         <note>Button label in tel: dialog to call a phone number. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.cancelButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.cancelButton">
         <source>Cancel</source>
         <target>Hủy bỏ</target>
         <note>Button label in external link dialog to cancel the dialog. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.emailButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.emailButton">
         <source>Email</source>
         <target>Thư điện tử</target>
         <note>Button label in mailto: dialog to send an email. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.messageTitleWithPlaceholder" xml:space="preserve">
+      <trans-unit id="ExternalLink.messageTitleWithPlaceholder">
         <source>You are now leaving %@.</source>
         <target>Bạn đang rời khỏi %@.</target>
         <note>Dialog title used for Maps/App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreButton">
         <source>Open App Store</source>
         <target>Mở App Store</target>
         <note>Button label in App Store URL dialog to open the App Store. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreTitle" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreTitle">
         <source>%@ wants to open the App Store.</source>
         <target>%@ muốn mở App Store.</target>
         <note>Dialog title used to open App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openMapsButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openMapsButton">
         <source>Open Maps</source>
         <target>Mở Bản đồ</target>
         <note>Button label in Maps URL dialog to open Maps. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="FindInPage.Done" xml:space="preserve">
+      <trans-unit id="FindInPage.Done">
         <source>Find in page done</source>
         <target>Hoàn thành tìm kiếm</target>
         <note>Accessibility label for done button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.NextResult" xml:space="preserve">
+      <trans-unit id="FindInPage.NextResult">
         <source>Find next in page</source>
         <target>Kết quả tiếp theo trong trang</target>
         <note>Accessibility label for next result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.PreviousResult" xml:space="preserve">
+      <trans-unit id="FindInPage.PreviousResult">
         <source>Find previous in page</source>
         <target>Kết quả trước trong trang</target>
         <note>Accessibility label for previous result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FirstRun.lastSlide.buttonLabel" xml:space="preserve">
+      <trans-unit id="FirstRun.lastSlide.buttonLabel">
         <source>OK, Got It!</source>
         <target>OK, được rồi!</target>
         <note>Label on button to dismiss first run UI</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelDescription" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelDescription">
         <source>Automatically block online trackers while you browse. Then tap to erase visited pages, searches, cookies and passwords from your device.</source>
         <target>Tự động chặn các trình theo dõi trực tuyến trong khi duyệt web. Sau đó chạm để xóa các trang đã ghé thăm, tìm kiếm, cookie và mật khẩu từ thiết bị của bạn.</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelTagline" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelTagline">
         <source>Browse like no one’s watching.</source>
         <target>Duyệt như không ai xem.</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="Focus.handoffSyncing" xml:space="preserve">
+      <trans-unit id="Focus.handoffSyncing">
         <source>Apple Handoff is syncing</source>
         <target>Apple Handoff đang đồng bộ</target>
         <note>Title for the loading screen when the handoff of clipboard delays Focus launch. “Handoff” should not be localized, see https://support.apple.com/HT204681</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel1" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel1">
         <source>Automatic private browsing.</source>
         <target>Duyệt web riêng tư.</target>
         <note>First label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel2" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel2">
         <source>Browse. Erase. Repeat.</source>
         <target>Duyệt. Xóa. Lặp lại.</target>
         <note>Second label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Menu.Close" xml:space="preserve">
+      <trans-unit id="Menu.Close">
         <source>Close</source>
         <target>Đóng</target>
         <note>Button label used to close a menu that displays as a popup.</note>
       </trans-unit>
-      <trans-unit id="Open.Cancel" xml:space="preserve">
+      <trans-unit id="Open.Cancel">
         <source>Cancel</source>
         <target>Hủy bỏ</target>
         <note>Label in share alert to cancel the alert</note>
       </trans-unit>
-      <trans-unit id="Open.Firefox" xml:space="preserve">
+      <trans-unit id="Open.Firefox">
         <source>Firefox (Private Browsing)</source>
         <target>Firefox (Duyệt Web riêng tư)</target>
         <note>Label in share alert to open the URL in Firefox</note>
       </trans-unit>
-      <trans-unit id="Open.More" xml:space="preserve">
+      <trans-unit id="Open.More">
         <source>More</source>
         <target>Thêm</target>
         <note>Label in share alert to open the full system share menu</note>
       </trans-unit>
-      <trans-unit id="Open.Safari" xml:space="preserve">
+      <trans-unit id="Open.Safari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Label in share alert to open the URL in Safari</note>
       </trans-unit>
-      <trans-unit id="Request Desktop Site" xml:space="preserve">
+      <trans-unit id="Request Desktop Site">
         <source>Request Desktop Site</source>
         <target>Yêu cầu trang web trên máy tính</target>
         <note>Label for button that requests the desktop version of the currently loaded website.</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsContentBlockers" xml:space="preserve">
+      <trans-unit id="Safari.instructionsContentBlockers">
         <source>Tap Safari, then select Content Blockers</source>
         <target>Chạm Safari, rồi chọn Chặn nội dung</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsEnable" xml:space="preserve">
+      <trans-unit id="Safari.instructionsEnable">
         <source>Enable %@</source>
         <target>Bật %@</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsNotEnabled" xml:space="preserve">
+      <trans-unit id="Safari.instructionsNotEnabled">
         <source>%@ is not enabled.</source>
         <target>%@ không được bật.</target>
         <note>Error label when the blocker is not enabled, shown in the intro and main app when disabled</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsOpen" xml:space="preserve">
+      <trans-unit id="Safari.instructionsOpen">
         <source>Open Settings App</source>
         <target>Mở Cài đặt</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Save" xml:space="preserve">
+      <trans-unit id="Save">
         <source>Save</source>
         <target>Lưu</target>
         <note>Save button label</note>
       </trans-unit>
-      <trans-unit id="SearchEngine.addEngineError" xml:space="preserve">
+      <trans-unit id="SearchEngine.addEngineError">
         <source>That didn't work. Try replacing the search term with this: %s.</source>
         <target>Điều đó không hoạt động. Hãy thử thay thế cụm từ tìm kiếm bằng cái này: %s.</target>
         <note>Label for error state when entering an invalid search engine URL. %s is a search term in a URL.</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptDisable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptDisable">
         <source>No</source>
         <target>Không</target>
         <note>Label for disable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptEnable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptEnable">
         <source>Yes</source>
         <target>Có</target>
         <note>Label for enable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptMessage" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptMessage">
         <source>To get suggestions, %@ needs to send what you type in the address bar to the search engine.</source>
         <target>Để nhận gợi ý, %@ cần gửi những gì bạn nhập vào thanh địa chỉ cho công cụ tìm kiếm.</target>
         <note>%@ is the name of the app (Focus / Klar). Label for search suggestions prompt message</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptTitle" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptTitle">
         <source>Show Search Suggestions?</source>
         <target>Hiển thị đề xuất tìm kiếm?</target>
         <note>Title for search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButton" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButton">
         <source>Add Another Search Engine</source>
         <target>Thêm công cụ tìm kiếm khác</target>
         <note>Text for button to add another search engine in settings</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus">
         <source>+ Add Another Search Engine</source>
         <target>+ Thêm công cụ tìm kiếm khác</target>
         <note>Text for button to add another search engine in settings with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineTitle" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineTitle">
         <source>Add Search Engine</source>
         <target>Thêm công cụ tìm kiếm</target>
         <note>Title on add search engine settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.InstalledSearchEngines" xml:space="preserve">
+      <trans-unit id="Settings.Search.InstalledSearchEngines">
         <source>INSTALLED SEARCH ENGINES</source>
         <target>CÔNG CỤ TÌM KIẾM ĐÃ CÀI ĐẶT</target>
         <note>Header for rows of installed search engines</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NameToDisplay" xml:space="preserve">
+      <trans-unit id="Settings.Search.NameToDisplay">
         <source>Name to display</source>
         <target>Tên hiển thị</target>
         <note>Label for input field for the name of the search engine to be added</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NewSearchEngineAdded" xml:space="preserve">
+      <trans-unit id="Settings.Search.NewSearchEngineAdded">
         <source>New Search Engine Added.</source>
         <target>Đã thêm công cụ tìm kiếm mới.</target>
         <note>Toast displayed after adding a search engine</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.RestoreEngine" xml:space="preserve">
+      <trans-unit id="Settings.Search.RestoreEngine">
         <source>Restore Default Search Engines</source>
         <target>Phục hồi các công cụ tìm kiếm mặc định</target>
         <note>Label for button to bring deleted default engines back</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchEngineName" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchEngineName">
         <source>Search engine name</source>
         <target>Tên công cụ tìm kiếm</target>
         <note>Placeholder text for input of new search engine name</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplate" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplate">
         <source>Search string to use</source>
         <target>Chuỗi tìm kiếm sử dụng</target>
         <note>Label for input of search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplatePlaceholder" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplatePlaceholder">
         <source>Paste or enter search string. If necessary, replace search term with: %s.</source>
         <target>Dán hoặc nhập chuỗi tìm kiếm. Nếu cần, hãy thay thế cụm từ tìm kiếm bằng: %s.</target>
         <note>Placeholder text for input of new search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.autocompleteSection" xml:space="preserve">
+      <trans-unit id="Settings.autocompleteSection">
         <source>URL Autocomplete</source>
         <target>Tự động điền URL</target>
         <note>Title for the URL Autocomplete row</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherMessage" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherMessage">
         <source>Blocking other content trackers may break some videos and web pages.</source>
         <target>Chặn các trình theo dõi nội dung khác có thể dẫn đến việc không xem được một vài video và trang web.</target>
         <note>Alert message shown when toggling the Content blocker</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherNo2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherNo2">
         <source>Cancel</source>
         <target>Hủy bỏ</target>
         <note>Button label for declining Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherYes2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherYes2">
         <source>Block Content Trackers</source>
         <target>Chặn trình theo dõi nội dung</target>
         <note>Button label for accepting Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSearchSuggestion" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSearchSuggestion">
         <source>%@ will send what you type in the address bar to your search engine.</source>
         <target>%@ sẽ gửi nội dung bạn nhập vào thanh địa chỉ đến công cụ tìm kiếm của bạn.</target>
         <note>Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSendUsageData">
         <source>Mozilla strives to collect only what we need to provide and improve %@ for everyone.</source>
         <target>Mozilla chỉ thu thập những gì chúng tôi cần cung cấp và cải tiến %@ cho tất cả mọi người.</target>
         <note>Description associated to the Send Usage Data toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.learnMore" xml:space="preserve">
+      <trans-unit id="Settings.learnMore">
         <source>Learn more.</source>
         <target>Tìm hiểu thêm.</target>
         <note>Subtitle for Send Anonymous Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.rate" xml:space="preserve">
+      <trans-unit id="Settings.rate">
         <source>Rate %@</source>
         <target>Đánh giá %@</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, allows the user to leave a review for the app on the app store.</note>
       </trans-unit>
-      <trans-unit id="Settings.safariTitle" xml:space="preserve">
+      <trans-unit id="Settings.safariTitle">
         <source>SAFARI INTEGRATION</source>
         <target>SAFARI INTEGRATION</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.screenTitle" xml:space="preserve">
+      <trans-unit id="Settings.screenTitle">
         <source>Settings</source>
         <target>Cài đặt</target>
         <note>Title for settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchLabel" xml:space="preserve">
+      <trans-unit id="Settings.searchLabel">
         <source>Search Engine</source>
         <target>Công cụ tìm kiếm</target>
         <note>Label for the search engine in the search screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchSuggestions" xml:space="preserve">
+      <trans-unit id="Settings.searchSuggestions">
         <source>Get Search Suggestions</source>
         <target>Nhận gợi ý tìm kiếm</target>
         <note>Label for the Search Suggestions toggle row</note>
       </trans-unit>
-      <trans-unit id="Settings.searchTitle2" xml:space="preserve">
+      <trans-unit id="Settings.searchTitle2">
         <source>SEARCH</source>
         <target>TÌM KIẾM</target>
         <note>Title for the search selection screen</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionIntegration" xml:space="preserve">
+      <trans-unit id="Settings.sectionIntegration">
         <source>INTEGRATION</source>
         <target>INTEGRATION</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionMozilla" xml:space="preserve">
+      <trans-unit id="Settings.sectionMozilla">
         <source>MOZILLA</source>
         <target>MOZILLA</target>
         <note>Section label for Mozilla toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPerformance" xml:space="preserve">
+      <trans-unit id="Settings.sectionPerformance">
         <source>PERFORMANCE</source>
         <target>HIỆU SUẤT</target>
         <note>Section label for performance toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPrivacy" xml:space="preserve">
+      <trans-unit id="Settings.sectionPrivacy">
         <source>PRIVACY</source>
         <target>RIÊNG TƯ</target>
         <note>Section label for privacy toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionSecurity" xml:space="preserve">
+      <trans-unit id="Settings.sectionSecurity">
         <source>SECURITY</source>
         <target>BẢO MẬT</target>
         <note>Header label for security toggles displayed in the settings menu</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAds2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAds2">
         <source>Advertising</source>
         <target>Quảng cáo</target>
         <note>Label for the checkbox to toggle Advertising trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAnalytics2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAnalytics2">
         <source>Analytics</source>
         <target>Phân tích</target>
         <note>Label for the checkbox to toggle Analytics trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockFonts" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockFonts">
         <source>Block web fonts</source>
         <target>Chặn phông chữ trang Web</target>
         <note>Label for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockOther2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockOther2">
         <source>Content</source>
         <target>Nội dung</target>
         <note>Label for the checkbox to toggle Other trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockSocial2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockSocial2">
         <source>Social</source>
         <target>Xã hội</target>
         <note>Label for the checkbox to toggle Social trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceID" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceID">
         <source>Use Face ID to unlock app</source>
         <target>Sử dụng nhận dạng khuôn mặt để mở ứng dụng</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceIDDescription">
         <source>Face ID can unlock %@ if a URL is already open in the app</source>
         <target>Face ID có thể mở khóa %@ nếu một URL đã được mở trong ứng dụng</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Face ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleHomeScreenTips" xml:space="preserve">
+      <trans-unit id="Settings.toggleHomeScreenTips">
         <source>Show home screen tips</source>
         <target>Hiện mẹo trên màn hình chính</target>
         <note>Show home screen tips toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleOtherSubtitle" xml:space="preserve">
+      <trans-unit id="Settings.toggleOtherSubtitle">
         <source>May break some videos and Web pages</source>
         <target>Có thể không phát được một số video và trang Web</target>
         <note>Label subtitle for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSafari" xml:space="preserve">
+      <trans-unit id="Settings.toggleSafari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Safari toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.toggleSendUsageData">
         <source>Send usage data</source>
         <target>Gửi dữ liệu sử dụng</target>
         <note>Label for Send Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchID" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchID">
         <source>Use Touch ID to unlock app</source>
         <target>Sử dụng Touch ID để mở ứng dụng</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchIDDescription">
         <source>Touch ID can unlock %@ if a URL is already open in the app</source>
         <target>Touch ID có thể mở khóa %@ nếu một URL đã được mở trong ứng dụng</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Touch ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOff" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOff">
         <source>Off</source>
         <target>Tắt</target>
         <note>Status off for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOn" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOn">
         <source>On</source>
         <target>Bật</target>
         <note>Status on for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.whatsNewTitle" xml:space="preserve">
+      <trans-unit id="Settings.whatsNewTitle">
         <source>What’s New</source>
         <target>Có gì mới</target>
         <note>Title for What's new screen</note>
       </trans-unit>
-      <trans-unit id="Settinsg.siriShortcutsTitle" xml:space="preserve">
+      <trans-unit id="Settinsg.siriShortcutsTitle">
         <source>SIRI SHORTCUTS</source>
         <target>SIRI SHORTCUTS</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.FindInPage" xml:space="preserve">
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>Tìm trong trang</target>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.GetFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.GetFirefox">
         <source>Get the Firefox App</source>
         <target>Tải ứng dụng Firefox</target>
         <note>Text for the share menu option when a user wants to open a page in Firefox but doesn’t have it installed. This string will not wrap in the interface. Instead, it will truncate. To prevent this, please keep the localized string to 18 or fewer characters. If your string runs longer than 18 characters, you can use 'Get Firefox' as the basis for your string. However, if at all possible, we’d like to signal to the user that they will be going to the App Store and installing the application from there. That is why we are using Get and App in the en-US string.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.PageActions" xml:space="preserve">
+      <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <target>Hành động trang</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestDesktop" xml:space="preserve">
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
         <target>Yêu cầu trang web trên máy tính</target>
         <note>Text for the share menu option when a user wants to reload the site as a desktop</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestMobile" xml:space="preserve">
+      <trans-unit id="ShareMenu.RequestMobile">
         <source>Request Mobile Site</source>
         <target>Yêu cầu trang web di động</target>
         <note>Text for the share menu option when a user wants to reload the site as a mobile device</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenChrome" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenChrome">
         <source>Open in Chrome</source>
         <target>Mở trong Chrome</target>
         <note>Text for the share menu option when a user wants to open the current website in the Chrome app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenFirefox">
         <source>Open in Firefox</source>
         <target>Mở trong Firefox</target>
         <note>Text for the share menu option when a user wants to open the current website in the Firefox app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenSafari" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenSafari">
         <source>Open in Safari</source>
         <target>Mở trong Safafi</target>
         <note>Text for the share menu option when a user wants to open the current website in the Safari app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.SharePage" xml:space="preserve">
+      <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <target>Chia sẻ trang với...</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
       </trans-unit>
-      <trans-unit id="Siri.add" xml:space="preserve">
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
+      </trans-unit>
+      <trans-unit id="Siri.add">
         <source>Add</source>
         <target>Thêm</target>
         <note>Button to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.addTo" xml:space="preserve">
+      <trans-unit id="Siri.addTo">
         <source>Add to Siri</source>
         <target>Thêm vào Siri</target>
         <note>Button to add a specified shortcut option to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.editOpenUrl" xml:space="preserve">
+      <trans-unit id="Siri.editOpenUrl">
         <source>Re-Record or Delete Shortcut</source>
         <target>Ghi lại hoặc xóa phím tắt</target>
         <note>Label for button to edit the Siri phrase or delete the Siri functionality.</note>
       </trans-unit>
-      <trans-unit id="Siri.erase" xml:space="preserve">
+      <trans-unit id="Siri.erase">
         <source>Erase</source>
         <target>Xóa</target>
         <note>Title of option in settings to set up Siri to erase</note>
       </trans-unit>
-      <trans-unit id="Siri.eraseAndOpen" xml:space="preserve">
+      <trans-unit id="Siri.eraseAndOpen">
         <source>Erase &amp; Open</source>
         <target>Xóa &amp; mở</target>
         <note>Title of option in settings to set up Siri to erase and then open the app.</note>
       </trans-unit>
-      <trans-unit id="Siri.favoriteUrl" xml:space="preserve">
+      <trans-unit id="Siri.favoriteUrl">
         <source>Open Favorite Site</source>
         <target>Mở trang yêu thích</target>
         <note>Title for screen to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.openURL" xml:space="preserve">
+      <trans-unit id="Siri.openURL">
         <source>Open Favorite Site</source>
         <target>Mở trang yêu thích</target>
         <note>Title of option in settings to set up Siri to open a specified URL in Focus/Klar.</note>
       </trans-unit>
-      <trans-unit id="Siri.urlToOpen" xml:space="preserve">
+      <trans-unit id="Siri.urlToOpen">
         <source>URL to open</source>
         <target>URL để mở</target>
         <note>Label for input to set a favorite URL to be opened by Siri.</note>
       </trans-unit>
-      <trans-unit id="URL.addToAutocompleteLabel" xml:space="preserve">
+      <trans-unit id="URL.addToAutocompleteLabel">
         <source>Add link to autocomplete</source>
         <target>Thêm liên kết vào tự động điền</target>
         <note>Label displayed for button used as a shortcut to add a link to the list of URLs to autocomplete.</note>
       </trans-unit>
-      <trans-unit id="URL.cancelLabel" xml:space="preserve">
+      <trans-unit id="URL.cancelLabel">
         <source>Cancel</source>
         <target>Hủy bỏ</target>
         <note>Label for cancel button shown when entering a URL or search</note>
       </trans-unit>
-      <trans-unit id="URL.contextMenu" xml:space="preserve">
+      <trans-unit id="URL.contextMenu">
         <source>Paste &amp; Go</source>
         <target>Dán &amp; mở</target>
         <note>Text for the URL context menu when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.eraseButtonLabel" xml:space="preserve">
+      <trans-unit id="URL.eraseButtonLabel">
         <source>ERASE</source>
         <target>XÓA</target>
         <note>Erase button in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.eraseMessageLabel2" xml:space="preserve">
+      <trans-unit id="URL.eraseMessageLabel2">
         <source>Browsing history cleared</source>
         <target>Đã xóa lịch sử duyệt web</target>
         <note>Message shown after pressing the Erase button</note>
       </trans-unit>
-      <trans-unit id="URL.findOnPageLabel" xml:space="preserve">
+      <trans-unit id="URL.findOnPageLabel">
         <source>Find in page: %@</source>
         <target>Tìm trong trang: %@</target>
         <note>Label displayed for find in page button when typing in the URL Bar. %@ is any text the user has typed into the URL bar that they want to find on the current page.</note>
       </trans-unit>
-      <trans-unit id="URL.paste" xml:space="preserve">
+      <trans-unit id="URL.paste">
         <source>Paste</source>
         <target>Dán</target>
         <note>Text for a menu displayed from the bottom of the screen when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.placeholderText" xml:space="preserve">
+      <trans-unit id="URL.placeholderText">
         <source>Search or enter address</source>
         <target>Tìm kiếm hoặc nhập địa chỉ</target>
         <note>Placeholder text shown in the URL bar before the user navigates to a page</note>
       </trans-unit>
-      <trans-unit id="URL.searchLabel" xml:space="preserve">
+      <trans-unit id="URL.searchLabel">
         <source>Search for %@</source>
         <target>Tìm kiếm cho %@</target>
         <note>Label displayed for search button when typing in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="URL.trackersBlockedLabel">
         <source>Trackers blocked</source>
         <target>Theo dõi bị chặn</target>
         <note>Text for the URL bar showing the number of trackers blocked on a webpage.</note>
       </trans-unit>
-      <trans-unit id="actionSheet.openIn" xml:space="preserve">
+      <trans-unit id="actionSheet.openIn">
         <source>Open in %@</source>
         <target>Mở trong %@</target>
         <note>Title for action sheet item to open the current page in another application. Placeholder is the name of the application to open the current page.</note>
       </trans-unit>
-      <trans-unit id="browser.copyAddressToast" xml:space="preserve">
+      <trans-unit id="browser.copyAddressToast">
         <source>URL Copied To Clipboard</source>
         <target>URL đã được sao chép vào clipboard</target>
         <note>Toast displayed after a URL has been copied to the clipboard</note>
       </trans-unit>
-      <trans-unit id="browserShortcutDescription.selectLocationBar" xml:space="preserve">
+      <trans-unit id="browserShortcutDescription.selectLocationBar">
         <source>Select Location Bar</source>
         <target>Chọn thanh địa chỉ</target>
         <note>Label to display in the Discoverability overlay for keyboard shortcuts</note>
       </trans-unit>
-      <trans-unit id="contextMenu.clipboardLink" xml:space="preserve">
+      <trans-unit id="contextMenu.clipboardLink">
         <source>Link you copied: %@</source>
         <target>Liên kết bạn sao chép: %@</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.copyImageTitle">
         <source>Copy Image</source>
         <target>Sao chép ảnh</target>
         <note>Text for the context menu when a user wants to copy an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyLink" xml:space="preserve">
+      <trans-unit id="contextMenu.copyLink">
         <source>Copy Link</source>
         <target>Sao chép liên kết</target>
         <note>Text for the context menu when a user wants to copy a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.linkCopied" xml:space="preserve">
+      <trans-unit id="contextMenu.linkCopied">
         <source>Link you copied: </source>
         <target>Liên kết bạn đã sao chép:</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.saveImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.saveImageTitle">
         <source>Save Image</source>
         <target>Lưu ảnh</target>
         <note>Text for the context menu when a user wants to save an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.shareLinkTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.shareLinkTitle">
         <source>Share Link</source>
         <target>Chia sẻ liên kết</target>
         <note>Text for the context menu when a user wants to share a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="externalAppLinkWithAppName.messageTitle" xml:space="preserve">
+      <trans-unit id="externalAppLinkWithAppName.messageTitle">
         <source>%1$@ wants to open %2$@</source>
         <target>%1$@ muốn mở %2$@</target>
         <note>Dialog title used for opening an external app from Focus. First placeholder string is the app name of either Focus or Klar and the second placeholder string specifies the app it wants to open.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.description" xml:space="preserve">
+      <trans-unit id="photosPermission.description">
         <source>This lets you save images to your Camera Roll</source>
         <target>Điều này cho phép bạn lưu ảnh đến Camera Roll của bạn</target>
         <note>Description for dialog used for requesting a user to enable access to Photos.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.openSettings" xml:space="preserve">
+      <trans-unit id="photosPermission.openSettings">
         <source>Open Settings</source>
         <target>Mở Cài đặt</target>
         <note>Title for button that takes the user to system settings</note>
       </trans-unit>
-      <trans-unit id="photosPermission.title" xml:space="preserve">
+      <trans-unit id="photosPermission.title">
         <source>“%@” Would Like to Access Your Photos</source>
         <target>“%@” muốn truy cập vào ảnh của bạn</target>
         <note>Dialog title used for requesting a user to enable access to Photos. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="settings.Search.SearchTemplateExample" xml:space="preserve">
+      <trans-unit id="settings.Search.SearchTemplateExample">
         <source>Example: searchengineexample.com/search/?q=%s</source>
         <target>Ví dụ: searchengineexample.com/search/?q=%s</target>
         <note>Text displayed as an example of the template to add a search engine.</note>
       </trans-unit>
-      <trans-unit id="share" xml:space="preserve">
+      <trans-unit id="share">
         <source>Share</source>
         <target>Chia sẻ</target>
         <note>Text for a share button</note>
       </trans-unit>
-      <trans-unit id="shareMenu.copyAddress" xml:space="preserve">
+      <trans-unit id="shareMenu.copyAddress">
         <source>Copy Address</source>
         <target>Sao chép địa chỉ liên kết</target>
         <note>Text for the share menu when a user wants to copy a URL.</note>
       </trans-unit>
-      <trans-unit id="touchId.reason" xml:space="preserve">
+      <trans-unit id="touchId.reason">
         <source>Use Touch ID to return to %@</source>
         <target>Sử dụng Touch ID để quay lại %@</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.adTrackersLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.adTrackersLabel">
         <source>Ad trackers</source>
         <target>Trình theo dõi quảng cáo</target>
         <note>Label for ad trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.analyticTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.analyticTrackerLabel">
         <source>Analytic trackers</source>
         <target>Trình theo dõi phân tích</target>
         <note>label for analytic trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.contentTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>
         <target>Trình theo dõi nội dung</target>
         <note>label for content trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.disabledLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.disabledLabel">
         <source>Tracking Protection off</source>
         <target>Chống theo dõi tắt</target>
         <note>text showing the tracking protection is disabled.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.label" xml:space="preserve">
+      <trans-unit id="trackingProtection.label">
         <source>Tracking Protection</source>
         <target>Trình chống theo dõi</target>
         <note>Title for the tracking settings page to change what trackers are blocked.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.labelDescription" xml:space="preserve">
+      <trans-unit id="trackingProtection.labelDescription">
         <source>Turning this off may fix some site problems</source>
         <target>Tắt tính năng này có thể khắc phục một số vấn đề về trang web</target>
         <note>Description/subtitle for the tracking protection label.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.learnMore" xml:space="preserve">
+      <trans-unit id="trackingProtection.learnMore">
         <source>Learn More</source>
         <target>Tìm hiểu thêm</target>
         <note>Text for the button to learn more about Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.moreSettings" xml:space="preserve">
+      <trans-unit id="trackingProtection.moreSettings">
         <source>More Settings</source>
         <target>Cài đặt khác</target>
         <note>Text for the button that closes the Shield Data and opens the regular Settings screen.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.socialTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.socialTrackerLabel">
         <source>Social trackers</source>
         <target>Trình theo dõi xã hội</target>
         <note>label for social trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOff" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOff">
         <source>Protections are OFF for this session</source>
         <target>Bảo vệ đã TẮT cho phiên này</target>
         <note>Text for the status off from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOn" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOn">
         <source>Protections are ON for this session</source>
         <target>Bảo vệ đã BẬT cho phiên này</target>
         <note>Text for the status on from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleDescription1" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleDescription1">
         <source>Disable until you close %@ or tap ERASE.</source>
         <target>Vô hiệu hóa cho đến khi bạn đóng %@ hoặc chạm ERASE.</target>
         <note>Description for the tracking protection toggle. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleLabel2">
         <source>Enhanced Tracking Protection</source>
         <target>Trình chống theo dõi nâng cao</target>
         <note>Text for the toggle that enables/disables tracking protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackerDescriptionLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackerDescriptionLabel2">
         <source>Keep your data to yourself. %@ protects you from many of the most common trackers that follow what you do online.</source>
         <target>Giữ dữ liệu của bạn cho chính mình. %@ bảo vệ bạn khỏi nhiều trình theo dõi phổ biến nhất theo dõi những gì bạn làm trực tuyến.</target>
         <note>General description of tracking protection settings, which is displayed underneath the trackers preferences in Settings. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersBlockedLabel">
         <source>Trackers blocked since %@</source>
         <target>Trình theo dõi bị chặn kể từ %@</target>
         <note>Text for tracking protection screen showing the number of trackers blocked since the app install. The placeholder is replaced with the install date of the application.</note>
@@ -1072,12 +1091,12 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Blockzilla/Settings.bundle/en.lproj/Root.strings" datatype="plaintext" source-language="en" target-language="vi">
+  <file original="Blockzilla/Settings.bundle/en.lproj/Root.strings" source-language="en" target-language="vi" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="SettingsBundle.Licenses" xml:space="preserve">
+      <trans-unit id="SettingsBundle.Licenses">
         <source>Licenses</source>
         <target>Giấy phép</target>
         <note>The title of the Licenses setting in the settings that Focus shows in the global iOS Settings app.</note>
@@ -1085,3 +1104,4 @@
     </body>
   </file>
 </xliff>
+

--- a/zh-CN/focus-ios.xliff
+++ b/zh-CN/focus-ios.xliff
@@ -1,36 +1,35 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Blockzilla/en.lproj/InfoPlist.strings" source-language="en" target-language="zh-CN" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="NSCameraUsageDescription" xml:space="preserve">
+      <trans-unit id="NSCameraUsageDescription">
         <source>This lets you take and upload photos.</source>
         <target>此权限让您可以拍摄和上传照片。</target>
         <note>Privacy - Camera Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSFaceIDUsageDescription" xml:space="preserve">
+      <trans-unit id="NSFaceIDUsageDescription">
         <source>This lets you unlock the app.</source>
         <target>让您可以解锁应用。</target>
         <note>Privacy - Face ID Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSLocationWhenInUseUsageDescription" xml:space="preserve">
+      <trans-unit id="NSLocationWhenInUseUsageDescription">
         <source>Websites you visit may request your location.</source>
         <target>您访问的网站可能请求您的位置。</target>
         <note>Privacy - Location When In Use Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSMicrophoneUsageDescription" xml:space="preserve">
+      <trans-unit id="NSMicrophoneUsageDescription">
         <source>This lets you take and upload videos.</source>
         <target>此权限让您可以拍摄和上传视频。</target>
         <note>Privacy - Microphone Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSPhotoLibraryAddUsageDescription" xml:space="preserve">
+      <trans-unit id="NSPhotoLibraryAddUsageDescription">
         <source>This lets you save and upload photos.</source>
         <target>此权限让您可以保存和上传照片。</target>
         <note>Privacy - Photo Library Additions Usage Description</note>
       </trans-unit>
-      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen" xml:space="preserve">
+      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen">
         <source>Erase and Open</source>
         <target>清除并打开</target>
         <note>This is the menu item that appears when you long press the Focus icon on the phone home screen.</note>
@@ -42,7 +41,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intents.Erase.Title" xml:space="preserve">
+      <trans-unit id="Intents.Erase.Title">
         <source>Erase</source>
         <target>清除</target>
         <note>Title of the Erase intent.</note>
@@ -54,42 +53,42 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intro.Slides.History.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Description">
         <source>Clear your entire browsing session history, passwords, cookies anytime with a single tap.</source>
         <target>随时一键清除您的所有浏览记录、密码及 Cookie。</target>
         <note>Description for the 'History' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.History.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Title">
         <source>Your history is history</source>
         <target>您的记录只属于您</target>
         <note>Title for the third  panel 'History' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Next.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Next.Button">
         <source>Next</source>
         <target>下一步</target>
         <note>Button to go to the next card in Focus onboarding.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Description">
         <source>Searching for something different? Choose a different search engine.</source>
         <target>想搜点不一样的东西？还可以选择其他搜索引擎。</target>
         <note>Description for the 'Favorite Search Engine' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Title">
         <source>Your search, your way</source>
         <target>你的搜索，由你而定</target>
         <note>Title for the second  panel 'Search' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Skip.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Skip.Button">
         <source>Skip</source>
         <target>跳过</target>
         <note>Button to skip onboarding in Focus</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Description">
         <source>Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times.</source>
         <target>将隐私浏览带入全新水平。屏蔽可以跨网站跟踪您的广告和其他内容，并减少网页加载时间。</target>
         <note>Description for the 'Welcome' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Title">
         <source>Power up your privacy</source>
         <target>强化您的隐私</target>
         <note>Title for the first panel 'Welcome' in the First Run tour.</note>
@@ -101,972 +100,992 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="About.learnMoreButton" xml:space="preserve">
+      <trans-unit id="About.learnMoreButton">
         <source>Learn more</source>
         <target>详细了解</target>
         <note>Button on About screen</note>
       </trans-unit>
-      <trans-unit id="About.missionLabel" xml:space="preserve">
+      <trans-unit id="About.missionLabel">
         <source>%@ is produced by Mozilla. Our mission is to foster a healthy, open Internet.</source>
         <target>%@ 由 Mozilla 出品。我们的使命是促成健康、开放的互联网。</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet1" xml:space="preserve">
+      <trans-unit id="About.privateBullet1">
         <source>Search and browse right in the app</source>
         <target>直接在应用中搜索和浏览</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet2" xml:space="preserve">
+      <trans-unit id="About.privateBullet2">
         <source>Block trackers (or update settings to allow trackers)</source>
         <target>拦截跟踪器（也可调整为允许跟踪器）</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet3" xml:space="preserve">
+      <trans-unit id="About.privateBullet3">
         <source>Erase to delete cookies as well as search and browsing history</source>
         <target>清除 Cookie、搜索记录和浏览记录</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBulletHeader" xml:space="preserve">
+      <trans-unit id="About.privateBulletHeader">
         <source>Use it as a private browser:</source>
         <target>用作私密浏览器，可以：</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowHelp" xml:space="preserve">
+      <trans-unit id="About.rowHelp">
         <source>Help</source>
         <target>帮助</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowPrivacy" xml:space="preserve">
+      <trans-unit id="About.rowPrivacy">
         <source>Privacy Notice</source>
         <target>隐私声明</target>
         <note>Link to Privacy Notice in the About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowRights" xml:space="preserve">
+      <trans-unit id="About.rowRights">
         <source>Your Rights</source>
         <target>您的权利</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet1" xml:space="preserve">
+      <trans-unit id="About.safariBullet1">
         <source>Block trackers for improved privacy</source>
         <target>拦截跟踪器，加强隐私</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet2" xml:space="preserve">
+      <trans-unit id="About.safariBullet2">
         <source>Block web fonts to reduce page size</source>
         <target>拦截网络字体，减少网页大小</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBulletHeader" xml:space="preserve">
+      <trans-unit id="About.safariBulletHeader">
         <source>Use it as a Safari extension:</source>
         <target>用作 Safari 扩展，可以：</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.title" xml:space="preserve">
+      <trans-unit id="About.title">
         <source>About %@</source>
         <target>关于 %@</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, takes the user to a page with information about the product. Also displayed as a header for the About page.</note>
       </trans-unit>
-      <trans-unit id="About.topLabel" xml:space="preserve">
+      <trans-unit id="About.topLabel">
         <source>%@ puts you in control.</source>
         <target>%@ 让您掌控线上生活。</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Dismiss" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Dismiss">
         <source>Ok</source>
         <target>确定</target>
         <note>Button to dismiss the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Message" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Message">
         <source>An error occured while adding the pass to Wallet. Please try again later.</source>
         <target>添加密码到 Apple 钱包时出错。请稍后重试。</target>
         <note>Message of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Title" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Title">
         <source>Failed to Add Pass</source>
         <target>添加密码失败</target>
         <note>Title of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="Authentication.reason" xml:space="preserve">
+      <trans-unit id="Authentication.reason">
         <source>Authenticate to return to %@</source>
         <target>验证身份以返回 %@</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID, Face ID, or passcode to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrl">
         <source>Add Custom URL</source>
         <target>添加自定义网址</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlError" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlError">
         <source>Double-check the URL you entered.</source>
         <target>请复查您输入的网址。</target>
         <note>Label for error state when entering an invalid URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlExample" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlExample">
         <source>Example: example.com</source>
         <target>例如：example.com</target>
         <note>A label displaying an example URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlLabel">
         <source>URL to add</source>
         <target>要添加的网址</target>
         <note>Label for the input to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlPlaceholder" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlPlaceholder">
         <source>Paste or enter URL</source>
         <target>粘贴或输入网址</target>
         <note>Placeholder for the input field to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlWithPlus" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlWithPlus">
         <source>+ Add Custom URL</source>
         <target>+ 添加自定义网址</target>
         <note>Label for button to add a custom URL with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.customDescriptoin">
         <source>Add and manage custom autocomplete URLs.</source>
         <target>添加和管理自定义的自动补全网址。</target>
         <note>Description for adding and managing custom autocomplete URLs</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.customLabel">
         <source>Custom URLs</source>
         <target>自定义网址</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.customTitle">
         <source>CUSTOM URL LIST</source>
         <target>自定义网址列表</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customUrlAdded" xml:space="preserve">
+      <trans-unit id="Autocomplete.customUrlAdded">
         <source>New Custom URL added.</source>
         <target>已添加新的自定义网址。</target>
         <note>Label for toast alerting a custom URL has been added</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultDescriptoin">
         <source>Enable to have %@ autocomplete over 450 popular URLs in the address bar.</source>
         <target>开启之后，%@ 地址栏可以自动补全超过 450 个热门网站。</target>
         <note>Description for enabling or disabling the default list. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultLabel">
         <source>Autocomplete</source>
         <target>自动补全</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultTitle">
         <source>DEFAULT URL LIST</source>
         <target>默认网址列表</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.disabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.disabled">
         <source>Disabled</source>
         <target>已禁用</target>
         <note>label describing URL Autocomplete as disabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.duplicateUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.duplicateUrl">
         <source>URL already exists</source>
         <target>网址已存在</target>
         <note>Label for toast alerting that the custom URL being added is a duplicate</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.emptyState" xml:space="preserve">
+      <trans-unit id="Autocomplete.emptyState">
         <source>No Custom URLs to display</source>
         <target>没有自定义网址</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.enabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.enabled">
         <source>Enabled</source>
         <target>已启用</target>
         <note>label describing URL Autocomplete as enabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.manageSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.manageSites">
         <source>Manage Sites</source>
         <target>管理网站</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySites" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySites">
         <source>My Sites</source>
         <target>我的网站</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySitesDesc" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySitesDesc">
         <source>Enable to have %@ autocomplete your favorite URLs.</source>
         <target>开启之后，%@ 可以自动补全您喜爱的网址。</target>
         <note>Description for adding and managing custom autocomplete URLs. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.topSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.topSites">
         <source>Top Sites</source>
         <target>常用网站</target>
         <note>Label for enabling or disabling top sites</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.newSession" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.newSession">
         <source>New Session</source>
         <target>新会话</target>
         <note>Create a new session after failing a biometric check</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.reason" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.reason">
         <source>Unlock %@ when re-opening in order to prevent unauthorized access.</source>
         <target>重新打开时要求解锁 %@，以防止未经您允许的使用。</target>
         <note>%@ is app name. Explanation for why the app needs access to biometric information. Prompt is only shown once when the user first tries to enable Face ID to open the app.</note>
       </trans-unit>
-      <trans-unit id="Browser.backLabel" xml:space="preserve">
+      <trans-unit id="Browser.backLabel">
         <source>Back</source>
         <target>后退</target>
         <note>Accessibility label for the back button</note>
       </trans-unit>
-      <trans-unit id="Browser.copyAddressLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyAddressLabel">
         <source>Copy Address</source>
         <target>复制地址</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.copyMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyMenuLabel">
         <source>Copy</source>
         <target>复制</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.customURLMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.customURLMenuLabel">
         <source>Add Custom URL</source>
         <target>添加自定义网址</target>
         <note>Custom URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.forwardLabel" xml:space="preserve">
+      <trans-unit id="Browser.forwardLabel">
         <source>Forward</source>
         <target>前进</target>
         <note>Accessibility label for the forward button</note>
       </trans-unit>
-      <trans-unit id="Browser.reloadLabel" xml:space="preserve">
+      <trans-unit id="Browser.reloadLabel">
         <source>Reload</source>
         <target>重新载入</target>
         <note>Accessibility label for the reload button</note>
       </trans-unit>
-      <trans-unit id="Browser.settingsLabel" xml:space="preserve">
+      <trans-unit id="Browser.settingsLabel">
         <source>Settings</source>
         <target>设置</target>
         <note>Accessibility label for the settings button</note>
       </trans-unit>
-      <trans-unit id="Browser.shareLabel" xml:space="preserve">
+      <trans-unit id="Browser.shareLabel">
         <source>Share</source>
         <target>分享</target>
         <note>Accessibility label for the share button</note>
       </trans-unit>
-      <trans-unit id="Browser.stopLabel" xml:space="preserve">
+      <trans-unit id="Browser.stopLabel">
         <source>Stop</source>
         <target>停止</target>
         <note>Accessibility label for the stop button</note>
       </trans-unit>
-      <trans-unit id="Cancel" xml:space="preserve">
+      <trans-unit id="Cancel">
         <source>Cancel</source>
         <target>取消</target>
         <note>Label on button to cancel edits</note>
       </trans-unit>
-      <trans-unit id="Done" xml:space="preserve">
+      <trans-unit id="Done">
         <source>Done</source>
         <target>完成</target>
         <note>Label on button to complete edits</note>
       </trans-unit>
-      <trans-unit id="Edit" xml:space="preserve">
+      <trans-unit id="Edit">
         <source>Edit</source>
         <target>编辑</target>
         <note>Label on button to allow edits</note>
       </trans-unit>
-      <trans-unit id="Error.tryAgainButton" xml:space="preserve">
+      <trans-unit id="Error.tryAgainButton">
         <source>Try again</source>
         <target>重试</target>
         <note>Button label to reload the error page</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.cancelTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.cancelTitle">
         <source>Cancel</source>
         <target>取消</target>
         <note>Button label used for cancelling to open another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.messageTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.messageTitle">
         <source>%@ wants to open another App</source>
         <target>%@ 想打开另一个应用</target>
         <note>Dialog title used for opening an external app from Focus. The placeholder string is the app name of either Focus or Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.openTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.openTitle">
         <source>Open</source>
         <target>打开</target>
         <note>Button label for opening another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.callButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.callButton">
         <source>Call</source>
         <target>拨叫</target>
         <note>Button label in tel: dialog to call a phone number. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.cancelButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.cancelButton">
         <source>Cancel</source>
         <target>取消</target>
         <note>Button label in external link dialog to cancel the dialog. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.emailButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.emailButton">
         <source>Email</source>
         <target>发邮件</target>
         <note>Button label in mailto: dialog to send an email. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.messageTitleWithPlaceholder" xml:space="preserve">
+      <trans-unit id="ExternalLink.messageTitleWithPlaceholder">
         <source>You are now leaving %@.</source>
         <target>您即将离开 %@。</target>
         <note>Dialog title used for Maps/App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreButton">
         <source>Open App Store</source>
         <target>打开 App Store</target>
         <note>Button label in App Store URL dialog to open the App Store. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreTitle" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreTitle">
         <source>%@ wants to open the App Store.</source>
         <target>%@ 想要打开 App Store。</target>
         <note>Dialog title used to open App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openMapsButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openMapsButton">
         <source>Open Maps</source>
         <target>打开地图</target>
         <note>Button label in Maps URL dialog to open Maps. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="FindInPage.Done" xml:space="preserve">
+      <trans-unit id="FindInPage.Done">
         <source>Find in page done</source>
         <target>查找完成</target>
         <note>Accessibility label for done button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.NextResult" xml:space="preserve">
+      <trans-unit id="FindInPage.NextResult">
         <source>Find next in page</source>
         <target>查找下一个</target>
         <note>Accessibility label for next result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.PreviousResult" xml:space="preserve">
+      <trans-unit id="FindInPage.PreviousResult">
         <source>Find previous in page</source>
         <target>查找上一个</target>
         <note>Accessibility label for previous result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FirstRun.lastSlide.buttonLabel" xml:space="preserve">
+      <trans-unit id="FirstRun.lastSlide.buttonLabel">
         <source>OK, Got It!</source>
         <target>明白了</target>
         <note>Label on button to dismiss first run UI</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelDescription" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelDescription">
         <source>Automatically block online trackers while you browse. Then tap to erase visited pages, searches, cookies and passwords from your device.</source>
         <target>在您浏览时自动拦截在线跟踪器。一按即可清除您的设备上的访问记录、搜索记录、Cookie 以及密码。</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelTagline" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelTagline">
         <source>Browse like no one’s watching.</source>
         <target>畅游网络，拒绝监视。</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="Focus.handoffSyncing" xml:space="preserve">
+      <trans-unit id="Focus.handoffSyncing">
         <source>Apple Handoff is syncing</source>
         <target>通用剪贴板（Handoff）正在同步</target>
         <note>Title for the loading screen when the handoff of clipboard delays Focus launch. “Handoff” should not be localized, see https://support.apple.com/HT204681</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel1" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel1">
         <source>Automatic private browsing.</source>
         <target>全自动的隐私浏览。</target>
         <note>First label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel2" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel2">
         <source>Browse. Erase. Repeat.</source>
         <target>无痕浏览，不必劳心。</target>
         <note>Second label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Menu.Close" xml:space="preserve">
+      <trans-unit id="Menu.Close">
         <source>Close</source>
         <target>关闭</target>
         <note>Button label used to close a menu that displays as a popup.</note>
       </trans-unit>
-      <trans-unit id="Open.Cancel" xml:space="preserve">
+      <trans-unit id="Open.Cancel">
         <source>Cancel</source>
         <target>取消</target>
         <note>Label in share alert to cancel the alert</note>
       </trans-unit>
-      <trans-unit id="Open.Firefox" xml:space="preserve">
+      <trans-unit id="Open.Firefox">
         <source>Firefox (Private Browsing)</source>
         <target>Firefox (隐私浏览)</target>
         <note>Label in share alert to open the URL in Firefox</note>
       </trans-unit>
-      <trans-unit id="Open.More" xml:space="preserve">
+      <trans-unit id="Open.More">
         <source>More</source>
         <target>更多</target>
         <note>Label in share alert to open the full system share menu</note>
       </trans-unit>
-      <trans-unit id="Open.Safari" xml:space="preserve">
+      <trans-unit id="Open.Safari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Label in share alert to open the URL in Safari</note>
       </trans-unit>
-      <trans-unit id="Request Desktop Site" xml:space="preserve">
+      <trans-unit id="Request Desktop Site">
         <source>Request Desktop Site</source>
         <target>要求桌面版网站</target>
         <note>Label for button that requests the desktop version of the currently loaded website.</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsContentBlockers" xml:space="preserve">
+      <trans-unit id="Safari.instructionsContentBlockers">
         <source>Tap Safari, then select Content Blockers</source>
         <target>点按 Safari，然后选择“内容拦截器”</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsEnable" xml:space="preserve">
+      <trans-unit id="Safari.instructionsEnable">
         <source>Enable %@</source>
         <target>启用 %@</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsNotEnabled" xml:space="preserve">
+      <trans-unit id="Safari.instructionsNotEnabled">
         <source>%@ is not enabled.</source>
         <target>%@ 未启用。</target>
         <note>Error label when the blocker is not enabled, shown in the intro and main app when disabled</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsOpen" xml:space="preserve">
+      <trans-unit id="Safari.instructionsOpen">
         <source>Open Settings App</source>
         <target>打开“设置”应用</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Save" xml:space="preserve">
+      <trans-unit id="Save">
         <source>Save</source>
         <target>保存</target>
         <note>Save button label</note>
       </trans-unit>
-      <trans-unit id="SearchEngine.addEngineError" xml:space="preserve">
+      <trans-unit id="SearchEngine.addEngineError">
         <source>That didn't work. Try replacing the search term with this: %s.</source>
         <target>网址无效。尝试用这个替换搜索关键词：%s。</target>
         <note>Label for error state when entering an invalid search engine URL. %s is a search term in a URL.</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptDisable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptDisable">
         <source>No</source>
         <target>否</target>
         <note>Label for disable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptEnable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptEnable">
         <source>Yes</source>
         <target>是</target>
         <note>Label for enable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptMessage" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptMessage">
         <source>To get suggestions, %@ needs to send what you type in the address bar to the search engine.</source>
         <target>为获取建议，%@ 需将您在地址栏中输入的内容发送至搜索引擎。</target>
         <note>%@ is the name of the app (Focus / Klar). Label for search suggestions prompt message</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptTitle" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptTitle">
         <source>Show Search Suggestions?</source>
         <target>要显示搜索建议吗？</target>
         <note>Title for search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButton" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButton">
         <source>Add Another Search Engine</source>
         <target>添加其他搜索引擎</target>
         <note>Text for button to add another search engine in settings</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus">
         <source>+ Add Another Search Engine</source>
         <target>+ 添加其他搜索引擎</target>
         <note>Text for button to add another search engine in settings with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineTitle" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineTitle">
         <source>Add Search Engine</source>
         <target>添加搜索引擎</target>
         <note>Title on add search engine settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.InstalledSearchEngines" xml:space="preserve">
+      <trans-unit id="Settings.Search.InstalledSearchEngines">
         <source>INSTALLED SEARCH ENGINES</source>
         <target>已安装的搜索引擎</target>
         <note>Header for rows of installed search engines</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NameToDisplay" xml:space="preserve">
+      <trans-unit id="Settings.Search.NameToDisplay">
         <source>Name to display</source>
         <target>显示名称</target>
         <note>Label for input field for the name of the search engine to be added</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NewSearchEngineAdded" xml:space="preserve">
+      <trans-unit id="Settings.Search.NewSearchEngineAdded">
         <source>New Search Engine Added.</source>
         <target>已添加新搜索引擎。</target>
         <note>Toast displayed after adding a search engine</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.RestoreEngine" xml:space="preserve">
+      <trans-unit id="Settings.Search.RestoreEngine">
         <source>Restore Default Search Engines</source>
         <target>恢复默认搜索引擎</target>
         <note>Label for button to bring deleted default engines back</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchEngineName" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchEngineName">
         <source>Search engine name</source>
         <target>搜索引擎名称</target>
         <note>Placeholder text for input of new search engine name</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplate" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplate">
         <source>Search string to use</source>
         <target>搜索字符串</target>
         <note>Label for input of search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplatePlaceholder" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplatePlaceholder">
         <source>Paste or enter search string. If necessary, replace search term with: %s.</source>
         <target>粘贴或输入搜索字符串。如果必要，用 %s 表示搜索关键词。</target>
         <note>Placeholder text for input of new search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.autocompleteSection" xml:space="preserve">
+      <trans-unit id="Settings.autocompleteSection">
         <source>URL Autocomplete</source>
         <target>网址自动补全</target>
         <note>Title for the URL Autocomplete row</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherMessage" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherMessage">
         <source>Blocking other content trackers may break some videos and web pages.</source>
         <target>拦截其他内容跟踪器可能对某些视频和网页有影响。</target>
         <note>Alert message shown when toggling the Content blocker</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherNo2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherNo2">
         <source>Cancel</source>
         <target>取消</target>
         <note>Button label for declining Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherYes2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherYes2">
         <source>Block Content Trackers</source>
         <target>拦截内容跟踪器</target>
         <note>Button label for accepting Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSearchSuggestion" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSearchSuggestion">
         <source>%@ will send what you type in the address bar to your search engine.</source>
         <target>%@ 会将您在地址栏中输入的内容发送至您的搜索引擎。</target>
         <note>Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSendUsageData">
         <source>Mozilla strives to collect only what we need to provide and improve %@ for everyone.</source>
         <target>Mozilla 坚持仅收集用来为大众改进 %@ 所必需的数据。</target>
         <note>Description associated to the Send Usage Data toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.learnMore" xml:space="preserve">
+      <trans-unit id="Settings.learnMore">
         <source>Learn more.</source>
         <target>详细了解。</target>
         <note>Subtitle for Send Anonymous Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.rate" xml:space="preserve">
+      <trans-unit id="Settings.rate">
         <source>Rate %@</source>
         <target>为 %@ 打分</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, allows the user to leave a review for the app on the app store.</note>
       </trans-unit>
-      <trans-unit id="Settings.safariTitle" xml:space="preserve">
+      <trans-unit id="Settings.safariTitle">
         <source>SAFARI INTEGRATION</source>
         <target>Safari 整合</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.screenTitle" xml:space="preserve">
+      <trans-unit id="Settings.screenTitle">
         <source>Settings</source>
         <target>设置</target>
         <note>Title for settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchLabel" xml:space="preserve">
+      <trans-unit id="Settings.searchLabel">
         <source>Search Engine</source>
         <target>搜索引擎</target>
         <note>Label for the search engine in the search screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchSuggestions" xml:space="preserve">
+      <trans-unit id="Settings.searchSuggestions">
         <source>Get Search Suggestions</source>
         <target>获取搜索建议</target>
         <note>Label for the Search Suggestions toggle row</note>
       </trans-unit>
-      <trans-unit id="Settings.searchTitle2" xml:space="preserve">
+      <trans-unit id="Settings.searchTitle2">
         <source>SEARCH</source>
         <target>搜索</target>
         <note>Title for the search selection screen</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionIntegration" xml:space="preserve">
+      <trans-unit id="Settings.sectionIntegration">
         <source>INTEGRATION</source>
         <target>集成</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionMozilla" xml:space="preserve">
+      <trans-unit id="Settings.sectionMozilla">
         <source>MOZILLA</source>
         <target>MOZILLA</target>
         <note>Section label for Mozilla toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPerformance" xml:space="preserve">
+      <trans-unit id="Settings.sectionPerformance">
         <source>PERFORMANCE</source>
         <target>性能</target>
         <note>Section label for performance toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPrivacy" xml:space="preserve">
+      <trans-unit id="Settings.sectionPrivacy">
         <source>PRIVACY</source>
         <target>隐私</target>
         <note>Section label for privacy toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionSecurity" xml:space="preserve">
+      <trans-unit id="Settings.sectionSecurity">
         <source>SECURITY</source>
         <target>安全</target>
         <note>Header label for security toggles displayed in the settings menu</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAds2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAds2">
         <source>Advertising</source>
         <target>营销</target>
         <note>Label for the checkbox to toggle Advertising trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAnalytics2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAnalytics2">
         <source>Analytics</source>
         <target>统计</target>
         <note>Label for the checkbox to toggle Analytics trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockFonts" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockFonts">
         <source>Block web fonts</source>
         <target>拦截网络字体</target>
         <note>Label for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockOther2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockOther2">
         <source>Content</source>
         <target>内容</target>
         <note>Label for the checkbox to toggle Other trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockSocial2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockSocial2">
         <source>Social</source>
         <target>社交</target>
         <note>Label for the checkbox to toggle Social trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceID" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceID">
         <source>Use Face ID to unlock app</source>
         <target>使用面容 ID 解锁应用</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceIDDescription">
         <source>Face ID can unlock %@ if a URL is already open in the app</source>
         <target>如果已有网址在应用中打开，则可用面容 ID 解锁 %@</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Face ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleHomeScreenTips" xml:space="preserve">
+      <trans-unit id="Settings.toggleHomeScreenTips">
         <source>Show home screen tips</source>
         <target>显示主屏幕提示</target>
         <note>Show home screen tips toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleOtherSubtitle" xml:space="preserve">
+      <trans-unit id="Settings.toggleOtherSubtitle">
         <source>May break some videos and Web pages</source>
         <target>可能对某些网页与视频有影响</target>
         <note>Label subtitle for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSafari" xml:space="preserve">
+      <trans-unit id="Settings.toggleSafari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Safari toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.toggleSendUsageData">
         <source>Send usage data</source>
         <target>发送使用统计</target>
         <note>Label for Send Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchID" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchID">
         <source>Use Touch ID to unlock app</source>
         <target>使用触控 ID 解锁应用</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchIDDescription">
         <source>Touch ID can unlock %@ if a URL is already open in the app</source>
         <target>如果已有网址在应用中打开，则可用触控 ID 解锁 %@</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Touch ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOff" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOff">
         <source>Off</source>
         <target>关闭</target>
         <note>Status off for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOn" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOn">
         <source>On</source>
         <target>开启</target>
         <note>Status on for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.whatsNewTitle" xml:space="preserve">
+      <trans-unit id="Settings.whatsNewTitle">
         <source>What’s New</source>
         <target>新版变化</target>
         <note>Title for What's new screen</note>
       </trans-unit>
-      <trans-unit id="Settinsg.siriShortcutsTitle" xml:space="preserve">
+      <trans-unit id="Settinsg.siriShortcutsTitle">
         <source>SIRI SHORTCUTS</source>
         <target>Siri 捷径</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.FindInPage" xml:space="preserve">
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>在页面中查找</target>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.GetFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.GetFirefox">
         <source>Get the Firefox App</source>
         <target>获取 Firefox 应用</target>
         <note>Text for the share menu option when a user wants to open a page in Firefox but doesn’t have it installed. This string will not wrap in the interface. Instead, it will truncate. To prevent this, please keep the localized string to 18 or fewer characters. If your string runs longer than 18 characters, you can use 'Get Firefox' as the basis for your string. However, if at all possible, we’d like to signal to the user that they will be going to the App Store and installing the application from there. That is why we are using Get and App in the en-US string.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.PageActions" xml:space="preserve">
+      <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <target>页面动作</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestDesktop" xml:space="preserve">
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
         <target>要求桌面版网站</target>
         <note>Text for the share menu option when a user wants to reload the site as a desktop</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestMobile" xml:space="preserve">
+      <trans-unit id="ShareMenu.RequestMobile">
         <source>Request Mobile Site</source>
         <target>请求移动版网站</target>
         <note>Text for the share menu option when a user wants to reload the site as a mobile device</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenChrome" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenChrome">
         <source>Open in Chrome</source>
         <target>在 Chrome 中打开</target>
         <note>Text for the share menu option when a user wants to open the current website in the Chrome app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenFirefox">
         <source>Open in Firefox</source>
         <target>在 Firefox 中打开</target>
         <note>Text for the share menu option when a user wants to open the current website in the Firefox app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenSafari" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenSafari">
         <source>Open in Safari</source>
         <target>在 Safari 中打开</target>
         <note>Text for the share menu option when a user wants to open the current website in the Safari app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.SharePage" xml:space="preserve">
+      <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <target>分享页面…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
       </trans-unit>
-      <trans-unit id="Siri.add" xml:space="preserve">
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
+      </trans-unit>
+      <trans-unit id="Siri.add">
         <source>Add</source>
         <target>添加</target>
         <note>Button to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.addTo" xml:space="preserve">
+      <trans-unit id="Siri.addTo">
         <source>Add to Siri</source>
         <target>添加到 Siri</target>
         <note>Button to add a specified shortcut option to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.editOpenUrl" xml:space="preserve">
+      <trans-unit id="Siri.editOpenUrl">
         <source>Re-Record or Delete Shortcut</source>
         <target>重新录制或删除捷径</target>
         <note>Label for button to edit the Siri phrase or delete the Siri functionality.</note>
       </trans-unit>
-      <trans-unit id="Siri.erase" xml:space="preserve">
+      <trans-unit id="Siri.erase">
         <source>Erase</source>
         <target>清除</target>
         <note>Title of option in settings to set up Siri to erase</note>
       </trans-unit>
-      <trans-unit id="Siri.eraseAndOpen" xml:space="preserve">
+      <trans-unit id="Siri.eraseAndOpen">
         <source>Erase &amp; Open</source>
         <target>清除并打开</target>
         <note>Title of option in settings to set up Siri to erase and then open the app.</note>
       </trans-unit>
-      <trans-unit id="Siri.favoriteUrl" xml:space="preserve">
+      <trans-unit id="Siri.favoriteUrl">
         <source>Open Favorite Site</source>
         <target>打开喜爱的网站</target>
         <note>Title for screen to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.openURL" xml:space="preserve">
+      <trans-unit id="Siri.openURL">
         <source>Open Favorite Site</source>
         <target>打开喜爱的网站</target>
         <note>Title of option in settings to set up Siri to open a specified URL in Focus/Klar.</note>
       </trans-unit>
-      <trans-unit id="Siri.urlToOpen" xml:space="preserve">
+      <trans-unit id="Siri.urlToOpen">
         <source>URL to open</source>
         <target>要打开的网址</target>
         <note>Label for input to set a favorite URL to be opened by Siri.</note>
       </trans-unit>
-      <trans-unit id="URL.addToAutocompleteLabel" xml:space="preserve">
+      <trans-unit id="URL.addToAutocompleteLabel">
         <source>Add link to autocomplete</source>
         <target>添加自动补全的链接</target>
         <note>Label displayed for button used as a shortcut to add a link to the list of URLs to autocomplete.</note>
       </trans-unit>
-      <trans-unit id="URL.cancelLabel" xml:space="preserve">
+      <trans-unit id="URL.cancelLabel">
         <source>Cancel</source>
         <target>取消</target>
         <note>Label for cancel button shown when entering a URL or search</note>
       </trans-unit>
-      <trans-unit id="URL.contextMenu" xml:space="preserve">
+      <trans-unit id="URL.contextMenu">
         <source>Paste &amp; Go</source>
         <target>粘贴并前往</target>
         <note>Text for the URL context menu when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.eraseButtonLabel" xml:space="preserve">
+      <trans-unit id="URL.eraseButtonLabel">
         <source>ERASE</source>
         <target>清除</target>
         <note>Erase button in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.eraseMessageLabel2" xml:space="preserve">
+      <trans-unit id="URL.eraseMessageLabel2">
         <source>Browsing history cleared</source>
         <target>浏览历史已清除</target>
         <note>Message shown after pressing the Erase button</note>
       </trans-unit>
-      <trans-unit id="URL.findOnPageLabel" xml:space="preserve">
+      <trans-unit id="URL.findOnPageLabel">
         <source>Find in page: %@</source>
         <target>在页面中查找：%@</target>
         <note>Label displayed for find in page button when typing in the URL Bar. %@ is any text the user has typed into the URL bar that they want to find on the current page.</note>
       </trans-unit>
-      <trans-unit id="URL.paste" xml:space="preserve">
+      <trans-unit id="URL.paste">
         <source>Paste</source>
         <target>粘贴</target>
         <note>Text for a menu displayed from the bottom of the screen when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.placeholderText" xml:space="preserve">
+      <trans-unit id="URL.placeholderText">
         <source>Search or enter address</source>
         <target>搜索或输入网址</target>
         <note>Placeholder text shown in the URL bar before the user navigates to a page</note>
       </trans-unit>
-      <trans-unit id="URL.searchLabel" xml:space="preserve">
+      <trans-unit id="URL.searchLabel">
         <source>Search for %@</source>
         <target>搜索 %@</target>
         <note>Label displayed for search button when typing in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="URL.trackersBlockedLabel">
         <source>Trackers blocked</source>
         <target>跟踪器已阻止</target>
         <note>Text for the URL bar showing the number of trackers blocked on a webpage.</note>
       </trans-unit>
-      <trans-unit id="actionSheet.openIn" xml:space="preserve">
+      <trans-unit id="actionSheet.openIn">
         <source>Open in %@</source>
         <target>在 %@ 中打开</target>
         <note>Title for action sheet item to open the current page in another application. Placeholder is the name of the application to open the current page.</note>
       </trans-unit>
-      <trans-unit id="browser.copyAddressToast" xml:space="preserve">
+      <trans-unit id="browser.copyAddressToast">
         <source>URL Copied To Clipboard</source>
         <target>网址已复制到剪贴板</target>
         <note>Toast displayed after a URL has been copied to the clipboard</note>
       </trans-unit>
-      <trans-unit id="browserShortcutDescription.selectLocationBar" xml:space="preserve">
+      <trans-unit id="browserShortcutDescription.selectLocationBar">
         <source>Select Location Bar</source>
         <target>选择地址栏</target>
         <note>Label to display in the Discoverability overlay for keyboard shortcuts</note>
       </trans-unit>
-      <trans-unit id="contextMenu.clipboardLink" xml:space="preserve">
+      <trans-unit id="contextMenu.clipboardLink">
         <source>Link you copied: %@</source>
         <target>已复制链接：%@</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.copyImageTitle">
         <source>Copy Image</source>
         <target>复制图像</target>
         <note>Text for the context menu when a user wants to copy an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyLink" xml:space="preserve">
+      <trans-unit id="contextMenu.copyLink">
         <source>Copy Link</source>
         <target>复制链接</target>
         <note>Text for the context menu when a user wants to copy a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.linkCopied" xml:space="preserve">
+      <trans-unit id="contextMenu.linkCopied">
         <source>Link you copied: </source>
         <target>已复制链接：</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.saveImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.saveImageTitle">
         <source>Save Image</source>
         <target>保存图像</target>
         <note>Text for the context menu when a user wants to save an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.shareLinkTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.shareLinkTitle">
         <source>Share Link</source>
         <target>分享链接</target>
         <note>Text for the context menu when a user wants to share a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="externalAppLinkWithAppName.messageTitle" xml:space="preserve">
+      <trans-unit id="externalAppLinkWithAppName.messageTitle">
         <source>%1$@ wants to open %2$@</source>
         <target>%1$@ 想打开 %2$@</target>
         <note>Dialog title used for opening an external app from Focus. First placeholder string is the app name of either Focus or Klar and the second placeholder string specifies the app it wants to open.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.description" xml:space="preserve">
+      <trans-unit id="photosPermission.description">
         <source>This lets you save images to your Camera Roll</source>
         <target>这让您可以将图像保存到您的相机胶卷</target>
         <note>Description for dialog used for requesting a user to enable access to Photos.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.openSettings" xml:space="preserve">
+      <trans-unit id="photosPermission.openSettings">
         <source>Open Settings</source>
         <target>打开设置</target>
         <note>Title for button that takes the user to system settings</note>
       </trans-unit>
-      <trans-unit id="photosPermission.title" xml:space="preserve">
+      <trans-unit id="photosPermission.title">
         <source>“%@” Would Like to Access Your Photos</source>
         <target>“%@”想要访问您的照片</target>
         <note>Dialog title used for requesting a user to enable access to Photos. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="settings.Search.SearchTemplateExample" xml:space="preserve">
+      <trans-unit id="settings.Search.SearchTemplateExample">
         <source>Example: searchengineexample.com/search/?q=%s</source>
         <target>例如：searchengineexample.com/search/?q=%s</target>
         <note>Text displayed as an example of the template to add a search engine.</note>
       </trans-unit>
-      <trans-unit id="share" xml:space="preserve">
+      <trans-unit id="share">
         <source>Share</source>
         <target>分享</target>
         <note>Text for a share button</note>
       </trans-unit>
-      <trans-unit id="shareMenu.copyAddress" xml:space="preserve">
+      <trans-unit id="shareMenu.copyAddress">
         <source>Copy Address</source>
         <target>复制地址</target>
         <note>Text for the share menu when a user wants to copy a URL.</note>
       </trans-unit>
-      <trans-unit id="touchId.reason" xml:space="preserve">
+      <trans-unit id="touchId.reason">
         <source>Use Touch ID to return to %@</source>
         <target>使用触控 ID 返回 %@</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.adTrackersLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.adTrackersLabel">
         <source>Ad trackers</source>
         <target>广告跟踪器</target>
         <note>Label for ad trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.analyticTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.analyticTrackerLabel">
         <source>Analytic trackers</source>
         <target>分析跟踪器</target>
         <note>label for analytic trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.contentTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>
         <target>内容跟踪器</target>
         <note>label for content trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.disabledLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.disabledLabel">
         <source>Tracking Protection off</source>
         <target>关闭跟踪保护</target>
         <note>text showing the tracking protection is disabled.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.label" xml:space="preserve">
+      <trans-unit id="trackingProtection.label">
         <source>Tracking Protection</source>
         <target>跟踪保护</target>
         <note>Title for the tracking settings page to change what trackers are blocked.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.labelDescription" xml:space="preserve">
+      <trans-unit id="trackingProtection.labelDescription">
         <source>Turning this off may fix some site problems</source>
         <target>关闭此功能或许可以解决一些网站的问题</target>
         <note>Description/subtitle for the tracking protection label.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.learnMore" xml:space="preserve">
+      <trans-unit id="trackingProtection.learnMore">
         <source>Learn More</source>
         <target>详细了解</target>
         <note>Text for the button to learn more about Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.moreSettings" xml:space="preserve">
+      <trans-unit id="trackingProtection.moreSettings">
         <source>More Settings</source>
         <target>更多设置</target>
         <note>Text for the button that closes the Shield Data and opens the regular Settings screen.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.socialTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.socialTrackerLabel">
         <source>Social trackers</source>
         <target>社交跟踪器</target>
         <note>label for social trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOff" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOff">
         <source>Protections are OFF for this session</source>
         <target>对此会话已关闭保护</target>
         <note>Text for the status off from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOn" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOn">
         <source>Protections are ON for this session</source>
         <target>对此会话已开启保护</target>
         <note>Text for the status on from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleDescription1" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleDescription1">
         <source>Disable until you close %@ or tap ERASE.</source>
         <target>禁用至您关闭 %@ 或按“清除”。</target>
         <note>Description for the tracking protection toggle. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleLabel2">
         <source>Enhanced Tracking Protection</source>
         <target>增强型跟踪保护</target>
         <note>Text for the toggle that enables/disables tracking protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackerDescriptionLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackerDescriptionLabel2">
         <source>Keep your data to yourself. %@ protects you from many of the most common trackers that follow what you do online.</source>
         <target>你的数据只由你掌握。%@ 可保护您免受大多数常见的跟踪器对您在线活动的窥视。</target>
         <note>General description of tracking protection settings, which is displayed underneath the trackers preferences in Settings. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersBlockedLabel">
         <source>Trackers blocked since %@</source>
         <target>自 %@ 起拦截的跟踪器</target>
         <note>Text for tracking protection screen showing the number of trackers blocked since the app install. The placeholder is replaced with the install date of the application.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersHeader" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersHeader">
         <source>Trackers and scripts to block</source>
         <target>要拦截的跟踪器和脚本</target>
         <note>Text for the header of trackers section from Tracking Protection.</note>
@@ -1078,7 +1097,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="SettingsBundle.Licenses" xml:space="preserve">
+      <trans-unit id="SettingsBundle.Licenses">
         <source>Licenses</source>
         <target>许可协议</target>
         <note>The title of the Licenses setting in the settings that Focus shows in the global iOS Settings app.</note>
@@ -1086,3 +1105,4 @@
     </body>
   </file>
 </xliff>
+

--- a/zh-TW/focus-ios.xliff
+++ b/zh-TW/focus-ios.xliff
@@ -1,36 +1,35 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Blockzilla/en.lproj/InfoPlist.strings" source-language="en" target-language="zh-TW" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="NSCameraUsageDescription" xml:space="preserve">
+      <trans-unit id="NSCameraUsageDescription">
         <source>This lets you take and upload photos.</source>
         <target>此權限讓您可拍照與上傳圖片。</target>
         <note>Privacy - Camera Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSFaceIDUsageDescription" xml:space="preserve">
+      <trans-unit id="NSFaceIDUsageDescription">
         <source>This lets you unlock the app.</source>
         <target>讓您可解鎖程式。</target>
         <note>Privacy - Face ID Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSLocationWhenInUseUsageDescription" xml:space="preserve">
+      <trans-unit id="NSLocationWhenInUseUsageDescription">
         <source>Websites you visit may request your location.</source>
         <target>您造訪的網站可能會向您請求您的所在位置。</target>
         <note>Privacy - Location When In Use Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSMicrophoneUsageDescription" xml:space="preserve">
+      <trans-unit id="NSMicrophoneUsageDescription">
         <source>This lets you take and upload videos.</source>
         <target>讓您可拍攝並上傳影片。</target>
         <note>Privacy - Microphone Usage Description</note>
       </trans-unit>
-      <trans-unit id="NSPhotoLibraryAddUsageDescription" xml:space="preserve">
+      <trans-unit id="NSPhotoLibraryAddUsageDescription">
         <source>This lets you save and upload photos.</source>
         <target>讓您可以儲存、上傳照片。</target>
         <note>Privacy - Photo Library Additions Usage Description</note>
       </trans-unit>
-      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen" xml:space="preserve">
+      <trans-unit id="UIApplicationShortcutItemTitle.EraseAndOpen">
         <source>Erase and Open</source>
         <target>清除並開啟</target>
         <note>This is the menu item that appears when you long press the Focus icon on the phone home screen.</note>
@@ -42,7 +41,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intents.Erase.Title" xml:space="preserve">
+      <trans-unit id="Intents.Erase.Title">
         <source>Erase</source>
         <target>清除</target>
         <note>Title of the Erase intent.</note>
@@ -54,42 +53,42 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="Intro.Slides.History.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Description">
         <source>Clear your entire browsing session history, passwords, cookies anytime with a single tap.</source>
         <target>只要輕鬆一點，就能清除這次上網的所有瀏覽紀錄、儲存密碼、Cookie 等資料。</target>
         <note>Description for the 'History' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.History.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.History.Title">
         <source>Your history is history</source>
         <target>瀏覽紀錄就是紀錄</target>
         <note>Title for the third  panel 'History' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Next.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Next.Button">
         <source>Next</source>
         <target>下一步</target>
         <note>Button to go to the next card in Focus onboarding.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Description">
         <source>Searching for something different? Choose a different search engine.</source>
         <target>想找找別的東西？選一套不同的搜尋引擎試試。</target>
         <note>Description for the 'Favorite Search Engine' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Search.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Search.Title">
         <source>Your search, your way</source>
         <target>用你的方式搜尋</target>
         <note>Title for the second  panel 'Search' in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Skip.Button" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Skip.Button">
         <source>Skip</source>
         <target>略過</target>
         <note>Button to skip onboarding in Focus</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Description" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Description">
         <source>Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times.</source>
         <target>隱私瀏覽功能變得更強大了。現在可封鎖廣告，以及其他可在不同網站間追蹤您的上網紀錄，又拖慢網頁載入的追蹤器。</target>
         <note>Description for the 'Welcome' panel in the First Run tour.</note>
       </trans-unit>
-      <trans-unit id="Intro.Slides.Welcome.Title" xml:space="preserve">
+      <trans-unit id="Intro.Slides.Welcome.Title">
         <source>Power up your privacy</source>
         <target>加強您的隱私</target>
         <note>Title for the first panel 'Welcome' in the First Run tour.</note>
@@ -101,972 +100,992 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="About.learnMoreButton" xml:space="preserve">
+      <trans-unit id="About.learnMoreButton">
         <source>Learn more</source>
         <target>了解更多</target>
         <note>Button on About screen</note>
       </trans-unit>
-      <trans-unit id="About.missionLabel" xml:space="preserve">
+      <trans-unit id="About.missionLabel">
         <source>%@ is produced by Mozilla. Our mission is to foster a healthy, open Internet.</source>
         <target>%@ 是由 Mozilla 所打造，我們的使命是培養一個健康、開放的網際網路。</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet1" xml:space="preserve">
+      <trans-unit id="About.privateBullet1">
         <source>Search and browse right in the app</source>
         <target>直接在程式中搜尋、瀏覽</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet2" xml:space="preserve">
+      <trans-unit id="About.privateBullet2">
         <source>Block trackers (or update settings to allow trackers)</source>
         <target>封鎖追蹤器（也可調整設定，允許追蹤器）</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBullet3" xml:space="preserve">
+      <trans-unit id="About.privateBullet3">
         <source>Erase to delete cookies as well as search and browsing history</source>
         <target>清除 Cookie、搜尋紀錄、上網紀錄</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.privateBulletHeader" xml:space="preserve">
+      <trans-unit id="About.privateBulletHeader">
         <source>Use it as a private browser:</source>
         <target>可當作私密瀏覽器使用:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowHelp" xml:space="preserve">
+      <trans-unit id="About.rowHelp">
         <source>Help</source>
         <target>說明</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowPrivacy" xml:space="preserve">
+      <trans-unit id="About.rowPrivacy">
         <source>Privacy Notice</source>
         <target>隱私權公告</target>
         <note>Link to Privacy Notice in the About screen</note>
       </trans-unit>
-      <trans-unit id="About.rowRights" xml:space="preserve">
+      <trans-unit id="About.rowRights">
         <source>Your Rights</source>
         <target>您的權利</target>
         <note>Label for row in About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet1" xml:space="preserve">
+      <trans-unit id="About.safariBullet1">
         <source>Block trackers for improved privacy</source>
         <target>封鎖追蹤器，加強隱私</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBullet2" xml:space="preserve">
+      <trans-unit id="About.safariBullet2">
         <source>Block web fonts to reduce page size</source>
         <target>封鎖網路字型，減少網頁大小</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.safariBulletHeader" xml:space="preserve">
+      <trans-unit id="About.safariBulletHeader">
         <source>Use it as a Safari extension:</source>
         <target>以 Safari 延伸功能使用:</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="About.title" xml:space="preserve">
+      <trans-unit id="About.title">
         <source>About %@</source>
         <target>關於 %@</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, takes the user to a page with information about the product. Also displayed as a header for the About page.</note>
       </trans-unit>
-      <trans-unit id="About.topLabel" xml:space="preserve">
+      <trans-unit id="About.topLabel">
         <source>%@ puts you in control.</source>
         <target>%@ 讓您可自行控制線上生活。</target>
         <note>Label on About screen</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Dismiss" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Dismiss">
         <source>Ok</source>
         <target>確定</target>
         <note>Button to dismiss the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Message" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Message">
         <source>An error occured while adding the pass to Wallet. Please try again later.</source>
         <target>新增票卡至 Wallet 時發生錯誤，請稍候再試一次。</target>
         <note>Message of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="AddPass.Error.Title" xml:space="preserve">
+      <trans-unit id="AddPass.Error.Title">
         <source>Failed to Add Pass</source>
         <target>新增票卡失敗</target>
         <note>Title of the 'Add Pass Failed' alert.</note>
       </trans-unit>
-      <trans-unit id="Authentication.reason" xml:space="preserve">
+      <trans-unit id="Authentication.reason">
         <source>Authenticate to return to %@</source>
         <target>驗證後即可回到 %@</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID, Face ID, or passcode to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrl">
         <source>Add Custom URL</source>
         <target>新增自訂網址</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlError" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlError">
         <source>Double-check the URL you entered.</source>
         <target>請檢查您輸入的網址。</target>
         <note>Label for error state when entering an invalid URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlExample" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlExample">
         <source>Example: example.com</source>
         <target>舉例: example.com</target>
         <note>A label displaying an example URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlLabel">
         <source>URL to add</source>
         <target>要新增的網址</target>
         <note>Label for the input to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlPlaceholder" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlPlaceholder">
         <source>Paste or enter URL</source>
         <target>貼上或輸入網址</target>
         <note>Placeholder for the input field to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.addCustomUrlWithPlus" xml:space="preserve">
+      <trans-unit id="Autocomplete.addCustomUrlWithPlus">
         <source>+ Add Custom URL</source>
         <target>+ 新增自訂網址</target>
         <note>Label for button to add a custom URL with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.customDescriptoin">
         <source>Add and manage custom autocomplete URLs.</source>
         <target>新增與管理自訂自動完成網址。</target>
         <note>Description for adding and managing custom autocomplete URLs</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.customLabel">
         <source>Custom URLs</source>
         <target>自訂網址</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.customTitle">
         <source>CUSTOM URL LIST</source>
         <target>自訂網址清單</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.customUrlAdded" xml:space="preserve">
+      <trans-unit id="Autocomplete.customUrlAdded">
         <source>New Custom URL added.</source>
         <target>已新增自訂網址。</target>
         <note>Label for toast alerting a custom URL has been added</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultDescriptoin" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultDescriptoin">
         <source>Enable to have %@ autocomplete over 450 popular URLs in the address bar.</source>
         <target>開啟後，即可在 %@ 網址列自動完成超過 450 組熱門網址。</target>
         <note>Description for enabling or disabling the default list. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultLabel" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultLabel">
         <source>Autocomplete</source>
         <target>自動完成</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.defaultTitle" xml:space="preserve">
+      <trans-unit id="Autocomplete.defaultTitle">
         <source>DEFAULT URL LIST</source>
         <target>預設網址清單</target>
         <note>Title for the default URL list section</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.disabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.disabled">
         <source>Disabled</source>
         <target>已停用</target>
         <note>label describing URL Autocomplete as disabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.duplicateUrl" xml:space="preserve">
+      <trans-unit id="Autocomplete.duplicateUrl">
         <source>URL already exists</source>
         <target>網址已經存在</target>
         <note>Label for toast alerting that the custom URL being added is a duplicate</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.emptyState" xml:space="preserve">
+      <trans-unit id="Autocomplete.emptyState">
         <source>No Custom URLs to display</source>
         <target>沒有可顯示的自訂網址</target>
         <note>Label for button to add a custom URL</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.enabled" xml:space="preserve">
+      <trans-unit id="Autocomplete.enabled">
         <source>Enabled</source>
         <target>已啟用</target>
         <note>label describing URL Autocomplete as enabled</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.manageSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.manageSites">
         <source>Manage Sites</source>
         <target>管理網站</target>
         <note>Label for button taking you to your custom Autocomplete URL list</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySites" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySites">
         <source>My Sites</source>
         <target>我的網站</target>
         <note>Label for enabling or disabling autocomplete</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.mySitesDesc" xml:space="preserve">
+      <trans-unit id="Autocomplete.mySitesDesc">
         <source>Enable to have %@ autocomplete your favorite URLs.</source>
         <target>開啟後，即可讓 %@ 自動完成您最愛的網址。</target>
         <note>Description for adding and managing custom autocomplete URLs. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="Autocomplete.topSites" xml:space="preserve">
+      <trans-unit id="Autocomplete.topSites">
         <source>Top Sites</source>
         <target>熱門網站</target>
         <note>Label for enabling or disabling top sites</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.newSession" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.newSession">
         <source>New Session</source>
         <target>開新使用階段</target>
         <note>Create a new session after failing a biometric check</note>
       </trans-unit>
-      <trans-unit id="BiometricPrompt.reason" xml:space="preserve">
+      <trans-unit id="BiometricPrompt.reason">
         <source>Unlock %@ when re-opening in order to prevent unauthorized access.</source>
         <target>重新開啟時要求解鎖 %@，以防止未授權使用。</target>
         <note>%@ is app name. Explanation for why the app needs access to biometric information. Prompt is only shown once when the user first tries to enable Face ID to open the app.</note>
       </trans-unit>
-      <trans-unit id="Browser.backLabel" xml:space="preserve">
+      <trans-unit id="Browser.backLabel">
         <source>Back</source>
         <target>上一頁</target>
         <note>Accessibility label for the back button</note>
       </trans-unit>
-      <trans-unit id="Browser.copyAddressLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyAddressLabel">
         <source>Copy Address</source>
         <target>複製網址</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.copyMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.copyMenuLabel">
         <source>Copy</source>
         <target>複製</target>
         <note>Copy URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.customURLMenuLabel" xml:space="preserve">
+      <trans-unit id="Browser.customURLMenuLabel">
         <source>Add Custom URL</source>
         <target>新增自訂網址</target>
         <note>Custom URL button in URL long press menu</note>
       </trans-unit>
-      <trans-unit id="Browser.forwardLabel" xml:space="preserve">
+      <trans-unit id="Browser.forwardLabel">
         <source>Forward</source>
         <target>下一頁</target>
         <note>Accessibility label for the forward button</note>
       </trans-unit>
-      <trans-unit id="Browser.reloadLabel" xml:space="preserve">
+      <trans-unit id="Browser.reloadLabel">
         <source>Reload</source>
         <target>重新載入</target>
         <note>Accessibility label for the reload button</note>
       </trans-unit>
-      <trans-unit id="Browser.settingsLabel" xml:space="preserve">
+      <trans-unit id="Browser.settingsLabel">
         <source>Settings</source>
         <target>設定</target>
         <note>Accessibility label for the settings button</note>
       </trans-unit>
-      <trans-unit id="Browser.shareLabel" xml:space="preserve">
+      <trans-unit id="Browser.shareLabel">
         <source>Share</source>
         <target>分享</target>
         <note>Accessibility label for the share button</note>
       </trans-unit>
-      <trans-unit id="Browser.stopLabel" xml:space="preserve">
+      <trans-unit id="Browser.stopLabel">
         <source>Stop</source>
         <target>停止</target>
         <note>Accessibility label for the stop button</note>
       </trans-unit>
-      <trans-unit id="Cancel" xml:space="preserve">
+      <trans-unit id="Cancel">
         <source>Cancel</source>
         <target>取消</target>
         <note>Label on button to cancel edits</note>
       </trans-unit>
-      <trans-unit id="Done" xml:space="preserve">
+      <trans-unit id="Done">
         <source>Done</source>
         <target>完成</target>
         <note>Label on button to complete edits</note>
       </trans-unit>
-      <trans-unit id="Edit" xml:space="preserve">
+      <trans-unit id="Edit">
         <source>Edit</source>
         <target>編輯</target>
         <note>Label on button to allow edits</note>
       </trans-unit>
-      <trans-unit id="Error.tryAgainButton" xml:space="preserve">
+      <trans-unit id="Error.tryAgainButton">
         <source>Try again</source>
         <target>再試一次</target>
         <note>Button label to reload the error page</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.cancelTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.cancelTitle">
         <source>Cancel</source>
         <target>取消</target>
         <note>Button label used for cancelling to open another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.messageTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.messageTitle">
         <source>%@ wants to open another App</source>
         <target>%@ 想要開啟其他程式</target>
         <note>Dialog title used for opening an external app from Focus. The placeholder string is the app name of either Focus or Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalAppLink.openTitle" xml:space="preserve">
+      <trans-unit id="ExternalAppLink.openTitle">
         <source>Open</source>
         <target>開啟</target>
         <note>Button label for opening another app from Focus</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.callButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.callButton">
         <source>Call</source>
         <target>撥號</target>
         <note>Button label in tel: dialog to call a phone number. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.cancelButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.cancelButton">
         <source>Cancel</source>
         <target>取消</target>
         <note>Button label in external link dialog to cancel the dialog. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.emailButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.emailButton">
         <source>Email</source>
         <target>寄信</target>
         <note>Button label in mailto: dialog to send an email. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.messageTitleWithPlaceholder" xml:space="preserve">
+      <trans-unit id="ExternalLink.messageTitleWithPlaceholder">
         <source>You are now leaving %@.</source>
         <target>您即將離開 %@。</target>
         <note>Dialog title used for Maps/App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreButton">
         <source>Open App Store</source>
         <target>開啟 App Store</target>
         <note>Button label in App Store URL dialog to open the App Store. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openAppStoreTitle" xml:space="preserve">
+      <trans-unit id="ExternalLink.openAppStoreTitle">
         <source>%@ wants to open the App Store.</source>
         <target>%@ 想開啟 App Store。</target>
         <note>Dialog title used to open App Store links. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar.</note>
       </trans-unit>
-      <trans-unit id="ExternalLink.openMapsButton" xml:space="preserve">
+      <trans-unit id="ExternalLink.openMapsButton">
         <source>Open Maps</source>
         <target>開啟地圖</target>
         <note>Button label in Maps URL dialog to open Maps. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html</note>
       </trans-unit>
-      <trans-unit id="FindInPage.Done" xml:space="preserve">
+      <trans-unit id="FindInPage.Done">
         <source>Find in page done</source>
         <target>搜尋完成</target>
         <note>Accessibility label for done button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.NextResult" xml:space="preserve">
+      <trans-unit id="FindInPage.NextResult">
         <source>Find next in page</source>
         <target>尋找下一筆</target>
         <note>Accessibility label for next result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FindInPage.PreviousResult" xml:space="preserve">
+      <trans-unit id="FindInPage.PreviousResult">
         <source>Find previous in page</source>
         <target>尋找上一筆</target>
         <note>Accessibility label for previous result button in Find in Page Toolbar.</note>
       </trans-unit>
-      <trans-unit id="FirstRun.lastSlide.buttonLabel" xml:space="preserve">
+      <trans-unit id="FirstRun.lastSlide.buttonLabel">
         <source>OK, Got It!</source>
         <target>好，知道了！</target>
         <note>Label on button to dismiss first run UI</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelDescription" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelDescription">
         <source>Automatically block online trackers while you browse. Then tap to erase visited pages, searches, cookies and passwords from your device.</source>
         <target>自動在您上網時封鎖線上追蹤器；只要一點即可清除裝置中造訪過的頁面、搜尋、Cookie、密碼等紀錄。</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="FirstRun.messageLabelTagline" xml:space="preserve">
+      <trans-unit id="FirstRun.messageLabelTagline">
         <source>Browse like no one’s watching.</source>
         <target>讓上網時不被偷看。</target>
         <note>Message label on the first run screen</note>
       </trans-unit>
-      <trans-unit id="Focus.handoffSyncing" xml:space="preserve">
+      <trans-unit id="Focus.handoffSyncing">
         <source>Apple Handoff is syncing</source>
         <target>Apple Handoff 同步中</target>
         <note>Title for the loading screen when the handoff of clipboard delays Focus launch. “Handoff” should not be localized, see https://support.apple.com/HT204681</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel1" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel1">
         <source>Automatic private browsing.</source>
         <target>自動進入隱私瀏覽模式，</target>
         <note>First label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Home.descriptionLabel2" xml:space="preserve">
+      <trans-unit id="Home.descriptionLabel2">
         <source>Browse. Erase. Repeat.</source>
         <target>無痕瀏覽，不留足跡。</target>
         <note>Second label for product description on the home screen</note>
       </trans-unit>
-      <trans-unit id="Menu.Close" xml:space="preserve">
+      <trans-unit id="Menu.Close">
         <source>Close</source>
         <target>關閉</target>
         <note>Button label used to close a menu that displays as a popup.</note>
       </trans-unit>
-      <trans-unit id="Open.Cancel" xml:space="preserve">
+      <trans-unit id="Open.Cancel">
         <source>Cancel</source>
         <target>取消</target>
         <note>Label in share alert to cancel the alert</note>
       </trans-unit>
-      <trans-unit id="Open.Firefox" xml:space="preserve">
+      <trans-unit id="Open.Firefox">
         <source>Firefox (Private Browsing)</source>
         <target>Firefox（隱私瀏覽）</target>
         <note>Label in share alert to open the URL in Firefox</note>
       </trans-unit>
-      <trans-unit id="Open.More" xml:space="preserve">
+      <trans-unit id="Open.More">
         <source>More</source>
         <target>更多</target>
         <note>Label in share alert to open the full system share menu</note>
       </trans-unit>
-      <trans-unit id="Open.Safari" xml:space="preserve">
+      <trans-unit id="Open.Safari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Label in share alert to open the URL in Safari</note>
       </trans-unit>
-      <trans-unit id="Request Desktop Site" xml:space="preserve">
+      <trans-unit id="Request Desktop Site">
         <source>Request Desktop Site</source>
         <target>開啟桌面版網站</target>
         <note>Label for button that requests the desktop version of the currently loaded website.</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsContentBlockers" xml:space="preserve">
+      <trans-unit id="Safari.instructionsContentBlockers">
         <source>Tap Safari, then select Content Blockers</source>
         <target>點擊 Safari，然後選擇「內容阻擋器」</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsEnable" xml:space="preserve">
+      <trans-unit id="Safari.instructionsEnable">
         <source>Enable %@</source>
         <target>開啟 %@</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsNotEnabled" xml:space="preserve">
+      <trans-unit id="Safari.instructionsNotEnabled">
         <source>%@ is not enabled.</source>
         <target>未開啟 %@。</target>
         <note>Error label when the blocker is not enabled, shown in the intro and main app when disabled</note>
       </trans-unit>
-      <trans-unit id="Safari.instructionsOpen" xml:space="preserve">
+      <trans-unit id="Safari.instructionsOpen">
         <source>Open Settings App</source>
         <target>開啟「設定」應用程式</target>
         <note>Label for instructions to enable Safari, shown when enabling Safari Integration in Settings</note>
       </trans-unit>
-      <trans-unit id="Save" xml:space="preserve">
+      <trans-unit id="Save">
         <source>Save</source>
         <target>儲存</target>
         <note>Save button label</note>
       </trans-unit>
-      <trans-unit id="SearchEngine.addEngineError" xml:space="preserve">
+      <trans-unit id="SearchEngine.addEngineError">
         <source>That didn't work. Try replacing the search term with this: %s.</source>
         <target>資料有誤。請將搜尋詞修改為: %s 然後再試一次。</target>
         <note>Label for error state when entering an invalid search engine URL. %s is a search term in a URL.</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptDisable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptDisable">
         <source>No</source>
         <target>關</target>
         <note>Label for disable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptEnable" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptEnable">
         <source>Yes</source>
         <target>開</target>
         <note>Label for enable option on search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptMessage" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptMessage">
         <source>To get suggestions, %@ needs to send what you type in the address bar to the search engine.</source>
         <target>為了取得建議，%@ 需要將您在網址列輸入的文字傳送至搜尋引擎。</target>
         <note>%@ is the name of the app (Focus / Klar). Label for search suggestions prompt message</note>
       </trans-unit>
-      <trans-unit id="SearchSuggestions.promptTitle" xml:space="preserve">
+      <trans-unit id="SearchSuggestions.promptTitle">
         <source>Show Search Suggestions?</source>
         <target>要顯示搜尋建議嗎？</target>
         <note>Title for search suggestions prompt</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButton" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButton">
         <source>Add Another Search Engine</source>
         <target>新增其他搜尋引擎</target>
         <note>Text for button to add another search engine in settings</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineButtonWithPlus">
         <source>+ Add Another Search Engine</source>
         <target>+ 新增其他搜尋引擎</target>
         <note>Text for button to add another search engine in settings with the + prefix</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.AddSearchEngineTitle" xml:space="preserve">
+      <trans-unit id="Settings.Search.AddSearchEngineTitle">
         <source>Add Search Engine</source>
         <target>新增搜尋引擎</target>
         <note>Title on add search engine settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.InstalledSearchEngines" xml:space="preserve">
+      <trans-unit id="Settings.Search.InstalledSearchEngines">
         <source>INSTALLED SEARCH ENGINES</source>
         <target>安裝的搜尋引擎</target>
         <note>Header for rows of installed search engines</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NameToDisplay" xml:space="preserve">
+      <trans-unit id="Settings.Search.NameToDisplay">
         <source>Name to display</source>
         <target>要顯示的名稱</target>
         <note>Label for input field for the name of the search engine to be added</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.NewSearchEngineAdded" xml:space="preserve">
+      <trans-unit id="Settings.Search.NewSearchEngineAdded">
         <source>New Search Engine Added.</source>
         <target>已加入新搜尋引擎。</target>
         <note>Toast displayed after adding a search engine</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.RestoreEngine" xml:space="preserve">
+      <trans-unit id="Settings.Search.RestoreEngine">
         <source>Restore Default Search Engines</source>
         <target>還原預設搜尋引擎</target>
         <note>Label for button to bring deleted default engines back</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchEngineName" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchEngineName">
         <source>Search engine name</source>
         <target>搜尋引擎名稱</target>
         <note>Placeholder text for input of new search engine name</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplate" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplate">
         <source>Search string to use</source>
         <target>要使用的搜尋字串</target>
         <note>Label for input of search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.Search.SearchTemplatePlaceholder" xml:space="preserve">
+      <trans-unit id="Settings.Search.SearchTemplatePlaceholder">
         <source>Paste or enter search string. If necessary, replace search term with: %s.</source>
         <target>請貼上或輸入搜尋字串。有需要的話，將搜尋詞修改為: %s。</target>
         <note>Placeholder text for input of new search engine template</note>
       </trans-unit>
-      <trans-unit id="Settings.autocompleteSection" xml:space="preserve">
+      <trans-unit id="Settings.autocompleteSection">
         <source>URL Autocomplete</source>
         <target>網址自動完成</target>
         <note>Title for the URL Autocomplete row</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherMessage" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherMessage">
         <source>Blocking other content trackers may break some videos and web pages.</source>
         <target>封鎖其他的內容追蹤器可能會影響網頁與影片載入。</target>
         <note>Alert message shown when toggling the Content blocker</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherNo2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherNo2">
         <source>Cancel</source>
         <target>取消</target>
         <note>Button label for declining Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.blockOtherYes2" xml:space="preserve">
+      <trans-unit id="Settings.blockOtherYes2">
         <source>Block Content Trackers</source>
         <target>封鎖內容追蹤器</target>
         <note>Button label for accepting Content blocker alert</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSearchSuggestion" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSearchSuggestion">
         <source>%@ will send what you type in the address bar to your search engine.</source>
         <target>您在網址列打字時，%@ 就會將您輸入的文字傳送到搜尋引擎。</target>
         <note>Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.detailTextSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.detailTextSendUsageData">
         <source>Mozilla strives to collect only what we need to provide and improve %@ for everyone.</source>
         <target>Mozilla 致力於只收集用來為眾人改善 %@ 所需的必要資料。</target>
         <note>Description associated to the Send Usage Data toggle on main screen. %@ is the app name (Focus/Klar)</note>
       </trans-unit>
-      <trans-unit id="Settings.learnMore" xml:space="preserve">
+      <trans-unit id="Settings.learnMore">
         <source>Learn more.</source>
         <target>了解更多。</target>
         <note>Subtitle for Send Anonymous Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.rate" xml:space="preserve">
+      <trans-unit id="Settings.rate">
         <source>Rate %@</source>
         <target>為 %@ 評分</target>
         <note>%@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, allows the user to leave a review for the app on the app store.</note>
       </trans-unit>
-      <trans-unit id="Settings.safariTitle" xml:space="preserve">
+      <trans-unit id="Settings.safariTitle">
         <source>SAFARI INTEGRATION</source>
         <target>Safari 整合</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.screenTitle" xml:space="preserve">
+      <trans-unit id="Settings.screenTitle">
         <source>Settings</source>
         <target>設定</target>
         <note>Title for settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchLabel" xml:space="preserve">
+      <trans-unit id="Settings.searchLabel">
         <source>Search Engine</source>
         <target>搜尋引擎</target>
         <note>Label for the search engine in the search screen</note>
       </trans-unit>
-      <trans-unit id="Settings.searchSuggestions" xml:space="preserve">
+      <trans-unit id="Settings.searchSuggestions">
         <source>Get Search Suggestions</source>
         <target>取得搜尋建議</target>
         <note>Label for the Search Suggestions toggle row</note>
       </trans-unit>
-      <trans-unit id="Settings.searchTitle2" xml:space="preserve">
+      <trans-unit id="Settings.searchTitle2">
         <source>SEARCH</source>
         <target>搜尋</target>
         <note>Title for the search selection screen</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionIntegration" xml:space="preserve">
+      <trans-unit id="Settings.sectionIntegration">
         <source>INTEGRATION</source>
         <target>整合</target>
         <note>Label for Safari integration section</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionMozilla" xml:space="preserve">
+      <trans-unit id="Settings.sectionMozilla">
         <source>MOZILLA</source>
         <target>Mozilla</target>
         <note>Section label for Mozilla toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPerformance" xml:space="preserve">
+      <trans-unit id="Settings.sectionPerformance">
         <source>PERFORMANCE</source>
         <target>效能</target>
         <note>Section label for performance toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionPrivacy" xml:space="preserve">
+      <trans-unit id="Settings.sectionPrivacy">
         <source>PRIVACY</source>
         <target>隱私</target>
         <note>Section label for privacy toggles</note>
       </trans-unit>
-      <trans-unit id="Settings.sectionSecurity" xml:space="preserve">
+      <trans-unit id="Settings.sectionSecurity">
         <source>SECURITY</source>
         <target>安全性</target>
         <note>Header label for security toggles displayed in the settings menu</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAds2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAds2">
         <source>Advertising</source>
         <target>廣告</target>
         <note>Label for the checkbox to toggle Advertising trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockAnalytics2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockAnalytics2">
         <source>Analytics</source>
         <target>統計</target>
         <note>Label for the checkbox to toggle Analytics trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockFonts" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockFonts">
         <source>Block web fonts</source>
         <target>封鎖網路字型</target>
         <note>Label for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockOther2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockOther2">
         <source>Content</source>
         <target>內容</target>
         <note>Label for the checkbox to toggle Other trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleBlockSocial2" xml:space="preserve">
+      <trans-unit id="Settings.toggleBlockSocial2">
         <source>Social</source>
         <target>社交</target>
         <note>Label for the checkbox to toggle Social trackers</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceID" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceID">
         <source>Use Face ID to unlock app</source>
         <target>使用 Face ID 解鎖程式</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleFaceIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleFaceIDDescription">
         <source>Face ID can unlock %@ if a URL is already open in the app</source>
         <target>若已在程式開啟網頁，允許使用 Face ID 解鎖 %@</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Face ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleHomeScreenTips" xml:space="preserve">
+      <trans-unit id="Settings.toggleHomeScreenTips">
         <source>Show home screen tips</source>
         <target>在主畫面顯示小秘訣</target>
         <note>Show home screen tips toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleOtherSubtitle" xml:space="preserve">
+      <trans-unit id="Settings.toggleOtherSubtitle">
         <source>May break some videos and Web pages</source>
         <target>可能會影響網頁與影片載入</target>
         <note>Label subtitle for toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSafari" xml:space="preserve">
+      <trans-unit id="Settings.toggleSafari">
         <source>Safari</source>
         <target>Safari</target>
         <note>Safari toggle label on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleSendUsageData" xml:space="preserve">
+      <trans-unit id="Settings.toggleSendUsageData">
         <source>Send usage data</source>
         <target>傳送使用資料</target>
         <note>Label for Send Usage Data toggle on main screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchID" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchID">
         <source>Use Touch ID to unlock app</source>
         <target>使用 Touch ID 解鎖程式</target>
         <note>Label for toggle on settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.toggleTouchIDDescription" xml:space="preserve">
+      <trans-unit id="Settings.toggleTouchIDDescription">
         <source>Touch ID can unlock %@ if a URL is already open in the app</source>
         <target>若已在程式開啟網頁，允許使用 Touch ID 解鎖 %@</target>
         <note>%@ is the name of the app (Focus / Klar). Description for 'Enable Touch ID' displayed under its respective toggle in the settings menu.</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOff" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOff">
         <source>Off</source>
         <target>關閉</target>
         <note>Status off for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.trackingProtectionOn" xml:space="preserve">
+      <trans-unit id="Settings.trackingProtectionOn">
         <source>On</source>
         <target>開啟</target>
         <note>Status on for tracking protection in settings screen</note>
       </trans-unit>
-      <trans-unit id="Settings.whatsNewTitle" xml:space="preserve">
+      <trans-unit id="Settings.whatsNewTitle">
         <source>What’s New</source>
         <target>有什麼新鮮事</target>
         <note>Title for What's new screen</note>
       </trans-unit>
-      <trans-unit id="Settinsg.siriShortcutsTitle" xml:space="preserve">
+      <trans-unit id="Settinsg.siriShortcutsTitle">
         <source>SIRI SHORTCUTS</source>
         <target>Siri 捷徑</target>
         <note>Title for settings section to enable different Siri Shortcuts.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.FindInPage" xml:space="preserve">
+      <trans-unit id="ShareMenu.AddToShortcuts">
+        <source>Add to Shortcuts</source>
+        <note>Text for the share menu option when a user wants to add the site to Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.FindInPage">
         <source>Find in Page</source>
         <target>在頁面中搜尋</target>
         <note>Text for the share menu option when a user wants to open the find in page menu</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.GetFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.GetFirefox">
         <source>Get the Firefox App</source>
         <target>下載 Firefox</target>
         <note>Text for the share menu option when a user wants to open a page in Firefox but doesn’t have it installed. This string will not wrap in the interface. Instead, it will truncate. To prevent this, please keep the localized string to 18 or fewer characters. If your string runs longer than 18 characters, you can use 'Get Firefox' as the basis for your string. However, if at all possible, we’d like to signal to the user that they will be going to the App Store and installing the application from there. That is why we are using Get and App in the en-US string.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.PageActions" xml:space="preserve">
+      <trans-unit id="ShareMenu.PageActions">
         <source>Page Actions</source>
         <target>頁面操作</target>
         <note>Title for the share menu where users can take actions for the current website they are on.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestDesktop" xml:space="preserve">
+      <trans-unit id="ShareMenu.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
+      </trans-unit>
+      <trans-unit id="ShareMenu.RequestDesktop">
         <source>Request Desktop Site</source>
         <target>開啟桌面版網站</target>
         <note>Text for the share menu option when a user wants to reload the site as a desktop</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestMobile" xml:space="preserve">
+      <trans-unit id="ShareMenu.RequestMobile">
         <source>Request Mobile Site</source>
         <target>開啟行動版網頁</target>
         <note>Text for the share menu option when a user wants to reload the site as a mobile device</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenChrome" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenChrome">
         <source>Open in Chrome</source>
         <target>使用 Chrome 開啟</target>
         <note>Text for the share menu option when a user wants to open the current website in the Chrome app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenFirefox" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenFirefox">
         <source>Open in Firefox</source>
         <target>使用 Firefox 開啟</target>
         <note>Text for the share menu option when a user wants to open the current website in the Firefox app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.ShareOpenSafari" xml:space="preserve">
+      <trans-unit id="ShareMenu.ShareOpenSafari">
         <source>Open in Safari</source>
         <target>使用 Safari 開啟</target>
         <note>Text for the share menu option when a user wants to open the current website in the Safari app.</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.SharePage" xml:space="preserve">
+      <trans-unit id="ShareMenu.SharePage">
         <source>Share Page With...</source>
         <target>分享頁面…</target>
         <note>Text for the share menu option when a user wants to share the current website they are on through another app.</note>
       </trans-unit>
-      <trans-unit id="Siri.add" xml:space="preserve">
+      <trans-unit id="ShortcutView.RemoveFromShortcuts">
+        <source>Remove from Shortcuts</source>
+        <note>Text for the long press on a shortcut option in context menu.</note>
+      </trans-unit>
+      <trans-unit id="Siri.add">
         <source>Add</source>
         <target>新增</target>
         <note>Button to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.addTo" xml:space="preserve">
+      <trans-unit id="Siri.addTo">
         <source>Add to Siri</source>
         <target>新增至 Siri</target>
         <note>Button to add a specified shortcut option to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.editOpenUrl" xml:space="preserve">
+      <trans-unit id="Siri.editOpenUrl">
         <source>Re-Record or Delete Shortcut</source>
         <target>重新記錄或刪除捷徑</target>
         <note>Label for button to edit the Siri phrase or delete the Siri functionality.</note>
       </trans-unit>
-      <trans-unit id="Siri.erase" xml:space="preserve">
+      <trans-unit id="Siri.erase">
         <source>Erase</source>
         <target>清除</target>
         <note>Title of option in settings to set up Siri to erase</note>
       </trans-unit>
-      <trans-unit id="Siri.eraseAndOpen" xml:space="preserve">
+      <trans-unit id="Siri.eraseAndOpen">
         <source>Erase &amp; Open</source>
         <target>清除並開啟</target>
         <note>Title of option in settings to set up Siri to erase and then open the app.</note>
       </trans-unit>
-      <trans-unit id="Siri.favoriteUrl" xml:space="preserve">
+      <trans-unit id="Siri.favoriteUrl">
         <source>Open Favorite Site</source>
         <target>開啟最愛網站</target>
         <note>Title for screen to add a favorite URL to Siri.</note>
       </trans-unit>
-      <trans-unit id="Siri.openURL" xml:space="preserve">
+      <trans-unit id="Siri.openURL">
         <source>Open Favorite Site</source>
         <target>開啟最愛網站</target>
         <note>Title of option in settings to set up Siri to open a specified URL in Focus/Klar.</note>
       </trans-unit>
-      <trans-unit id="Siri.urlToOpen" xml:space="preserve">
+      <trans-unit id="Siri.urlToOpen">
         <source>URL to open</source>
         <target>要開啟的網址</target>
         <note>Label for input to set a favorite URL to be opened by Siri.</note>
       </trans-unit>
-      <trans-unit id="URL.addToAutocompleteLabel" xml:space="preserve">
+      <trans-unit id="URL.addToAutocompleteLabel">
         <source>Add link to autocomplete</source>
         <target>加入鏈結來自動完成</target>
         <note>Label displayed for button used as a shortcut to add a link to the list of URLs to autocomplete.</note>
       </trans-unit>
-      <trans-unit id="URL.cancelLabel" xml:space="preserve">
+      <trans-unit id="URL.cancelLabel">
         <source>Cancel</source>
         <target>取消</target>
         <note>Label for cancel button shown when entering a URL or search</note>
       </trans-unit>
-      <trans-unit id="URL.contextMenu" xml:space="preserve">
+      <trans-unit id="URL.contextMenu">
         <source>Paste &amp; Go</source>
         <target>貼上並前往</target>
         <note>Text for the URL context menu when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.eraseButtonLabel" xml:space="preserve">
+      <trans-unit id="URL.eraseButtonLabel">
         <source>ERASE</source>
         <target>清除</target>
         <note>Erase button in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.eraseMessageLabel2" xml:space="preserve">
+      <trans-unit id="URL.eraseMessageLabel2">
         <source>Browsing history cleared</source>
         <target>已清除瀏覽紀錄</target>
         <note>Message shown after pressing the Erase button</note>
       </trans-unit>
-      <trans-unit id="URL.findOnPageLabel" xml:space="preserve">
+      <trans-unit id="URL.findOnPageLabel">
         <source>Find in page: %@</source>
         <target>在頁面中搜尋: %@</target>
         <note>Label displayed for find in page button when typing in the URL Bar. %@ is any text the user has typed into the URL bar that they want to find on the current page.</note>
       </trans-unit>
-      <trans-unit id="URL.paste" xml:space="preserve">
+      <trans-unit id="URL.paste">
         <source>Paste</source>
         <target>貼上</target>
         <note>Text for a menu displayed from the bottom of the screen when a user long presses on the URL bar with clipboard contents.</note>
       </trans-unit>
-      <trans-unit id="URL.placeholderText" xml:space="preserve">
+      <trans-unit id="URL.placeholderText">
         <source>Search or enter address</source>
         <target>搜尋或輸入網址</target>
         <note>Placeholder text shown in the URL bar before the user navigates to a page</note>
       </trans-unit>
-      <trans-unit id="URL.searchLabel" xml:space="preserve">
+      <trans-unit id="URL.searchLabel">
         <source>Search for %@</source>
         <target>搜尋 %@</target>
         <note>Label displayed for search button when typing in the URL bar</note>
       </trans-unit>
-      <trans-unit id="URL.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="URL.trackersBlockedLabel">
         <source>Trackers blocked</source>
         <target>已封鎖追蹤器數</target>
         <note>Text for the URL bar showing the number of trackers blocked on a webpage.</note>
       </trans-unit>
-      <trans-unit id="actionSheet.openIn" xml:space="preserve">
+      <trans-unit id="actionSheet.openIn">
         <source>Open in %@</source>
         <target>使用 %@ 開啟</target>
         <note>Title for action sheet item to open the current page in another application. Placeholder is the name of the application to open the current page.</note>
       </trans-unit>
-      <trans-unit id="browser.copyAddressToast" xml:space="preserve">
+      <trans-unit id="browser.copyAddressToast">
         <source>URL Copied To Clipboard</source>
         <target>已將網址複製至剪貼簿</target>
         <note>Toast displayed after a URL has been copied to the clipboard</note>
       </trans-unit>
-      <trans-unit id="browserShortcutDescription.selectLocationBar" xml:space="preserve">
+      <trans-unit id="browserShortcutDescription.selectLocationBar">
         <source>Select Location Bar</source>
         <target>選擇網址列</target>
         <note>Label to display in the Discoverability overlay for keyboard shortcuts</note>
       </trans-unit>
-      <trans-unit id="contextMenu.clipboardLink" xml:space="preserve">
+      <trans-unit id="contextMenu.clipboardLink">
         <source>Link you copied: %@</source>
         <target>您複製的鏈結: %@</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.copyImageTitle">
         <source>Copy Image</source>
         <target>複製圖片</target>
         <note>Text for the context menu when a user wants to copy an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.copyLink" xml:space="preserve">
+      <trans-unit id="contextMenu.copyLink">
         <source>Copy Link</source>
         <target>複製鏈結</target>
         <note>Text for the context menu when a user wants to copy a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.linkCopied" xml:space="preserve">
+      <trans-unit id="contextMenu.linkCopied">
         <source>Link you copied: </source>
         <target>您複製的鏈結:</target>
         <note>Text for the context menu when a user has a link on their clipboard.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.saveImageTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.saveImageTitle">
         <source>Save Image</source>
         <target>儲存圖片</target>
         <note>Text for the context menu when a user wants to save an image after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="contextMenu.shareLinkTitle" xml:space="preserve">
+      <trans-unit id="contextMenu.shareLinkTitle">
         <source>Share Link</source>
         <target>分享鏈結</target>
         <note>Text for the context menu when a user wants to share a link after long pressing it.</note>
       </trans-unit>
-      <trans-unit id="externalAppLinkWithAppName.messageTitle" xml:space="preserve">
+      <trans-unit id="externalAppLinkWithAppName.messageTitle">
         <source>%1$@ wants to open %2$@</source>
         <target>%1$@ 想要開啟 %2$@</target>
         <note>Dialog title used for opening an external app from Focus. First placeholder string is the app name of either Focus or Klar and the second placeholder string specifies the app it wants to open.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.description" xml:space="preserve">
+      <trans-unit id="photosPermission.description">
         <source>This lets you save images to your Camera Roll</source>
         <target>讓您可儲存圖片到相機膠捲</target>
         <note>Description for dialog used for requesting a user to enable access to Photos.</note>
       </trans-unit>
-      <trans-unit id="photosPermission.openSettings" xml:space="preserve">
+      <trans-unit id="photosPermission.openSettings">
         <source>Open Settings</source>
         <target>開啟設定</target>
         <note>Title for button that takes the user to system settings</note>
       </trans-unit>
-      <trans-unit id="photosPermission.title" xml:space="preserve">
+      <trans-unit id="photosPermission.title">
         <source>“%@” Would Like to Access Your Photos</source>
         <target>「%@」想存取您的照片</target>
         <note>Dialog title used for requesting a user to enable access to Photos. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="settings.Search.SearchTemplateExample" xml:space="preserve">
+      <trans-unit id="settings.Search.SearchTemplateExample">
         <source>Example: searchengineexample.com/search/?q=%s</source>
         <target>例如: searchengineexample.com/search/?q=%s</target>
         <note>Text displayed as an example of the template to add a search engine.</note>
       </trans-unit>
-      <trans-unit id="share" xml:space="preserve">
+      <trans-unit id="share">
         <source>Share</source>
         <target>分享</target>
         <note>Text for a share button</note>
       </trans-unit>
-      <trans-unit id="shareMenu.copyAddress" xml:space="preserve">
+      <trans-unit id="shareMenu.copyAddress">
         <source>Copy Address</source>
         <target>複製網址</target>
         <note>Text for the share menu when a user wants to copy a URL.</note>
       </trans-unit>
-      <trans-unit id="touchId.reason" xml:space="preserve">
+      <trans-unit id="touchId.reason">
         <source>Use Touch ID to return to %@</source>
         <target>使用 Touch ID 返回 %@</target>
         <note>%@ is app name. Prompt shown to ask the user to use Touch ID to continue browsing after returning to the app.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.adTrackersLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.adTrackersLabel">
         <source>Ad trackers</source>
         <target>廣告追蹤器</target>
         <note>Label for ad trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.analyticTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.analyticTrackerLabel">
         <source>Analytic trackers</source>
         <target>統計追蹤器</target>
         <note>label for analytic trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.contentTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.connectionNotSecureLabel">
+        <source>Connection is not secure</source>
+        <note>Text for tracking protection screen showing the connection is not secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.connectionSecureLabel">
+        <source>Connection is secure</source>
+        <note>Text for tracking protection screen showing the connection is secure</note>
+      </trans-unit>
+      <trans-unit id="trackingProtection.contentTrackerLabel">
         <source>Content trackers</source>
         <target>內容追蹤器</target>
         <note>label for content trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.disabledLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.disabledLabel">
         <source>Tracking Protection off</source>
         <target>關閉追蹤保護</target>
         <note>text showing the tracking protection is disabled.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.label" xml:space="preserve">
+      <trans-unit id="trackingProtection.label">
         <source>Tracking Protection</source>
         <target>追蹤保護</target>
         <note>Title for the tracking settings page to change what trackers are blocked.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.labelDescription" xml:space="preserve">
+      <trans-unit id="trackingProtection.labelDescription">
         <source>Turning this off may fix some site problems</source>
         <target>關閉此功能可能可以解決一些網站的問題</target>
         <note>Description/subtitle for the tracking protection label.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.learnMore" xml:space="preserve">
+      <trans-unit id="trackingProtection.learnMore">
         <source>Learn More</source>
         <target>了解更多</target>
         <note>Text for the button to learn more about Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.moreSettings" xml:space="preserve">
+      <trans-unit id="trackingProtection.moreSettings">
         <source>More Settings</source>
         <target>更多設定</target>
         <note>Text for the button that closes the Shield Data and opens the regular Settings screen.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.socialTrackerLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.socialTrackerLabel">
         <source>Social trackers</source>
         <target>社交追蹤器</target>
         <note>label for social trackers.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOff" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOff">
         <source>Protections are OFF for this session</source>
         <target>已關閉此瀏覽階段的追蹤保護</target>
         <note>Text for the status off from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.statusOn" xml:space="preserve">
+      <trans-unit id="trackingProtection.statusOn">
         <source>Protections are ON for this session</source>
         <target>已開啟此瀏覽階段的追蹤保護</target>
         <note>Text for the status on from Tracking Protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleDescription1" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleDescription1">
         <source>Disable until you close %@ or tap ERASE.</source>
         <target>直到關閉 %@ 或點擊「清除」前都停用。</target>
         <note>Description for the tracking protection toggle. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.toggleLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.toggleLabel2">
         <source>Enhanced Tracking Protection</source>
         <target>加強型追蹤保護</target>
         <note>Text for the toggle that enables/disables tracking protection.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackerDescriptionLabel2" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackerDescriptionLabel2">
         <source>Keep your data to yourself. %@ protects you from many of the most common trackers that follow what you do online.</source>
         <target>自己保留自己的資料。%@ 不讓常見的追蹤器記錄您的上網行為。</target>
         <note>General description of tracking protection settings, which is displayed underneath the trackers preferences in Settings. Placeholder is either Firefox Focus or Firefox Klar</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersBlockedLabel" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersBlockedLabel">
         <source>Trackers blocked since %@</source>
         <target>自 %@ 起封鎖的追蹤器</target>
         <note>Text for tracking protection screen showing the number of trackers blocked since the app install. The placeholder is replaced with the install date of the application.</note>
       </trans-unit>
-      <trans-unit id="trackingProtection.trackersHeader" xml:space="preserve">
+      <trans-unit id="trackingProtection.trackersHeader">
         <source>Trackers and scripts to block</source>
         <target>要封鎖的追蹤器與指令碼</target>
         <note>Text for the header of trackers section from Tracking Protection.</note>
@@ -1078,7 +1097,7 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5.1" build-num="12E507"/>
     </header>
     <body>
-      <trans-unit id="SettingsBundle.Licenses" xml:space="preserve">
+      <trans-unit id="SettingsBundle.Licenses">
         <source>Licenses</source>
         <target>授權條款</target>
         <note>The title of the Licenses setting in the settings that Focus shows in the global iOS Settings app.</note>
@@ -1086,3 +1105,4 @@
     </body>
   </file>
 </xliff>
+


### PR DESCRIPTION
New strings:

 - ShareMenu.AddToShortcuts
 - ShareMenu.RemoveFromShortcuts
 - ShortcutView.RemoveFromShortcuts
 - trackingProtection.connectionNotSecureLabel
 - trackingProtection.connectionSecureLabel

@Delphine I noticed that there are a few locales where strings were still invalidated for the case that I fixed yesterday. Unfortunately I don't have time to fix this in the export tool.