### PR TITLE
Fix broken XML in da/focus-ios.xliff

### DIFF
--- a/da/focus-ios.xliff
+++ b/da/focus-ios.xliff
@@ -782,7 +782,7 @@
         <source>Remove from Shortcuts</source>
         <note>Text for the share menu option when a user wants to remove the site from Shortcuts</note>
       </trans-unit>
-      <trans-unit id="ShareMenu.RequestDesktop"
+      <trans-unit id="ShareMenu.RequestDesktop" xml:space="preserve">
         <source>Request Desktop Site</source>
         <target>Bed om desktop-version</target>
         <note>Text for the share menu option when a user wants to reload the site as a desktop</note>


### PR DESCRIPTION
A trailing `>` is missing, breaking the parser.

I've also added `xml:space="preserve"`, since that appears to be used across the board.